### PR TITLE
Adjust the typos from the docs in the code #5 and #6

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 # unistore
 
-> A tiny 650b centralized state container with component bindings for [Preact].
+> A tiny 666b centralized state container with component bindings for [Preact].
 
 -   **Small** footprint compliments Preact nicely
 -   **Familiar** names and ideas from Redux-like libraries

--- a/unistore.js
+++ b/unistore.js
@@ -9,7 +9,7 @@ import { h, Component } from 'preact';
  *    let store = createStore();
  *    store.subscribe( state => console.log(state) );
  *    store.setState({ a: 'b' });   // logs { a: 'b' }
- *    store.setState({ c: 'd' });   // logs { c: 'd' }
+ *    store.setState({ c: 'd' });   // logs { a: 'b', c: 'd' }
  */
 export function createStore(state) {
 	let listeners = [];
@@ -45,7 +45,7 @@ export function createStore(state) {
 			listeners.splice(i, !!~i);
 		},
 
-		/** Retreive the current state object.
+		/** Retrieve the current state object.
 		 *  @returns {Object} state
 		 */
 		getState() {


### PR DESCRIPTION
Seems like the fixes for #5 and #6 were done in `Readme.md` and not in code(jsdocs). This addresses that.