### PR TITLE
Return the unsubscribe from the subscriber

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 # unistore
 
-> A tiny 650b centralized state container with component bindings for [Preact].
+> A tiny 680b centralized state container with component bindings for [Preact].
 
 -   **Small** footprint compliments Preact nicely
 -   **Familiar** names and ideas from Redux-like libraries
@@ -117,7 +117,7 @@ Creates a new store, which is a tiny evented state container.
 let store = createStore();
    store.subscribe( state => console.log(state) );
    store.setState({ a: 'b' });   // logs { a: 'b' }
-   store.setState({ c: 'd' });   // logs { a: 'b', c: 'd' }
+   store.setState({ c: 'd' });   // logs { c: 'd' }
 ```
 
 Returns **[store](#store)** 
@@ -137,11 +137,13 @@ Apply a partial state object to the current state, invoking registered listeners
 
 ##### subscribe
 
-Register a listener function to be called whenever state is changed.
+Register a listener function to be called whenever state is changed, and returns the unsubscribe for that listener.
 
 **Parameters**
 
 -   `listener` **[Function](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function)** 
+
+Returns **[Function](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function)** unsubscribe
 
 ##### unsubscribe
 
@@ -153,7 +155,7 @@ Remove a previously-registered listener function.
 
 ##### getState
 
-Retrieve the current state object.
+Retreive the current state object.
 
 Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** state
 

--- a/unistore.js
+++ b/unistore.js
@@ -30,11 +30,13 @@ export function createStore(state) {
 			for (let i=0; i<listeners.length; i++) listeners[i](state);
 		},
 
-		/** Register a listener function to be called whenever state is changed.
+		/** Register a listener function to be called whenever state is changed, and returns the unsubscribe for that listener.
 		 *  @param {Function} listener
+		 *  @return {Function} unsubscribe
 		 */
 		subscribe(listener) {
 			listeners.push(listener);
+			return () => this.unsubscribe(listener);
 		},
 
 		/** Remove a previously-registered listener function.
@@ -80,11 +82,12 @@ export function connect(mapStateToProps, actions) {
 					this.setState(null);
 				}
 			};
+			let unsub;
 			this.componentDidMount = () => {
-				store.subscribe(update);
+				unsub = store.subscribe(update);
 			};
 			this.componentWillUnmount = () => {
-				store.unsubscribe(update);
+				unsub();
 			};
 			this.render = props => h(Child, assign(assign(assign({}, boundActions), props), state));
 		}

--- a/unistore.test.js
+++ b/unistore.test.js
@@ -36,7 +36,7 @@ describe('createStore()', () => {
 		let sub2 = jest.fn();
 
 		let rval = store.subscribe(sub1);
-		expect(rval).toBe(undefined);
+		expect(rval).toBeInstanceOf(Function);
 
 		store.setState({ a: 'b' });
 		expect(sub1).toBeCalledWith(store.getState());
@@ -54,31 +54,47 @@ describe('createStore()', () => {
 
 		let sub1 = jest.fn();
 		let sub2 = jest.fn();
+		let sub3 = jest.fn();
 
 		store.subscribe(sub1);
 		store.subscribe(sub2);
+		let unsub3 = store.subscribe(sub3);
 
 		store.setState({ a: 'b' });
 		expect(sub1).toBeCalled();
 		expect(sub2).toBeCalled();
-		
+		expect(sub3).toBeCalled();
+
 		sub1.mockReset();
 		sub2.mockReset();
-		
+		sub3.mockReset();
+
 		store.unsubscribe(sub2);
 
 		store.setState({ c: 'd' });
 		expect(sub1).toBeCalled();
 		expect(sub2).not.toBeCalled();
+		expect(sub3).toBeCalled();
 
 		sub1.mockReset();
 		sub2.mockReset();
+		sub3.mockReset();
 
 		store.unsubscribe(sub1);
 		
 		store.setState({ e: 'f' });
 		expect(sub1).not.toBeCalled();
 		expect(sub2).not.toBeCalled();
+		expect(sub3).toBeCalled();
+
+		sub3.mockReset();
+
+		unsub3();
+
+		store.setState({ g: 'h' });
+		expect(sub1).not.toBeCalled();
+		expect(sub2).not.toBeCalled();
+		expect(sub3).not.toBeCalled();
 	});
 });
 


### PR DESCRIPTION
This introduces the return of unsubscriber, when doing a subscribe.

```js
let store = createStore();
let unsub = store.subscribe(state => modifyState(state));

// After you're done just call the unsubscriber from 'unsub'
unsub();
```

I often found that this little help goes a long way. Sure it comes with increase in size. Bumps it to `680B` but maybe you think it's worth it?