### PR TITLE
createAction must return a function

### DIFF
--- a/unistore.js
+++ b/unistore.js
@@ -131,7 +131,7 @@ function createAction(store, action) {
 			if (ret.then) ret.then(store.setState);
 			else store.setState(ret);
 		}
-	}
+	};
 }
 
 


### PR DESCRIPTION
Fixes the issue I reported in #15 , where `createStore` calls the action in stead of returning a new action-function