### PR TITLE
createAction must return a function

### DIFF
--- a/unistore.js
+++ b/unistore.js
@@ -131,7 +131,7 @@ function createAction(store, action) {
 			if (ret.then) ret.then(store.setState);
 			else store.setState(ret);
 		}
-	}
+	};
 }
 
 

--- a/unistore.js
+++ b/unistore.js
@@ -123,12 +123,14 @@ function mapActions(actions, store) {
 
 // Bind a single action to the store and sequester its return value.
 function createAction(store, action) {
-	let args = [store.getState()];
-	for (let i=0; i<arguments.length; i++) args.push(arguments[i]);
-	let ret = action.apply(store, args);
-	if (ret!=null) {
-		if (ret.then) ret.then(store.setState);
-		else store.setState(ret);
+	return function() {
+		let args = [store.getState()];
+		for (let i=0; i<arguments.length; i++) args.push(arguments[i]);
+		let ret = action.apply(store, args);
+		if (ret!=null) {
+			if (ret.then) ret.then(store.setState);
+			else store.setState(ret);
+		}
 	}
 }
 


### PR DESCRIPTION
Fixes the issue #15 where `createStore` calls the action in stead of returning a new action-function.