### PR TITLE
Make `index.d.ts` a proper top-level module

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2,41 +2,40 @@
 // S - Wrapped component state
 // K - Store state
 // I - Injected props to wrapped component
-declare module "unistore" {
-  import * as Preact from "preact";
 
-  export type Listener<K> = (state: K) => void;
+import * as Preact from "preact";
 
-  export interface Store<K> {
-    setState(update: object, overwrite: boolean): void;
-    subscribe(f: Listener<K>): void;
-    unsubscribe(f: Listener<K>): void;
-    getState(): K;
-  }
+export type Listener<K> = (state: K) => void;
 
-  export function createStore<K>(state: K): Store<K>;
+export interface Store<K> {
+  setState(update: object, overwrite: boolean): void;
+  subscribe(f: Listener<K>): void;
+  unsubscribe(f: Listener<K>): void;
+  getState(): K;
+}
 
-  export type ActionFn<K> = (state: K) => object;
+export function createStore<K>(state: K): Store<K>;
 
-  export interface ActionMap<K> {
-    [actionName: string]: ActionFn<K>;
-  }
+export type ActionFn<K> = (state: K) => object;
 
-  export type ActionCreator<K> = (store: Store<K>) => ActionMap<K>;
+export interface ActionMap<K> {
+  [actionName: string]: ActionFn<K>;
+}
 
-  export type StateMapper<T, K, I> = (state: K, props?: T) => I;
+export type ActionCreator<K> = (store: Store<K>) => ActionMap<K>;
 
-  // TODO: Child should not be `any`.
-  export function connect<T, S, K, I>(
-    mapStateToProps: string | Array<string> | StateMapper<T, K, I>,
-    actions?: ActionCreator<K> | object
-  ): (Child: any) => Preact.ComponentConstructor<T, S>;
+export type StateMapper<T, K, I> = (state: K, props?: T) => I;
 
-  export interface ProviderProps<T> {
-    store: Store<T>;
-  }
+// TODO: Child should not be `any`.
+export function connect<T, S, K, I>(
+  mapStateToProps: string | Array<string> | StateMapper<T, K, I>,
+  actions?: ActionCreator<K> | object
+): (Child: any) => Preact.ComponentConstructor<T, S>;
 
-  export class Provider<T> extends Preact.Component<ProviderProps<T>, {}> {
-    render(props: ProviderProps<T>, {}): Preact.VNode;
-  }
+export interface ProviderProps<T> {
+  store: Store<T>;
+}
+
+export class Provider<T> extends Preact.Component<ProviderProps<T>, {}> {
+  render(props: ProviderProps<T>, { }): Preact.VNode;
 }


### PR DESCRIPTION
You probably want to view this while [ignoring whitespace](https://github.com/developit/unistore/pull/24/files?w=1).

The way it's currently written, multiple different `.d.ts` files for `unistore` might come into conflict because the module name is being declared globally. This new way, you're relying on Node's resolution strategy instead. Same deal as [here](https://github.com/developit/preact/issues/904#issuecomment-336327698) for Preact.