### PR TITLE
Update TypeScript typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -17,7 +17,7 @@ export interface Store<K> {
 	getState(): K;
 }
 
-export function createStore<K>(state?: K): Store<K>;
+export default function createStore<K>(state?: K): Store<K>;
 
 export type ActionFn<K> = (state: K) => object;
 


### PR DESCRIPTION
This brings the typings up to date with the current code in master.

Open tasks:
- ~~[ ] Typesafe integrations~~

**EDIT:** Decided it's better for now to simply fix the `createStore` default export. The integrations seem to be picked up fine by the ts compiler.