### PR TITLE
Fix devtools reporting

### DIFF
--- a/devtools.js
+++ b/devtools.js
@@ -21,7 +21,11 @@ module.exports = function unistoreDevTools(store) {
 		store.subscribe(function (state, action) {
 			var actionName = action && action.name || 'setState';
 
-			if (!ignoreState) store.devtools.send(actionName, state);
+			if (!ignoreState) {
+				store.devtools.send(actionName, state);
+			} else {
+				ignoreState = false;
+			}
 		});
 	}
 


### PR DESCRIPTION
Hello! :) 
Cool library - learnt a lot from reading the source code.

I noticed there's a small bug in the devtools in the following case:
1. Actions are dispatched as normal
2. The devtools are used to jump to a certain state, which causes `ignoreState = true`
3. More actions are dispatched, but since `ignoreState` is still `true`, these do not get logged to the devtools

I fixed this by setting `ignoreState` back to `false` after the devtools action has been processed by the store.