### PR TITLE
fix: use the new __REDUX_DEVTOOLS_EXTENSION__

### DIFF
--- a/devtools.js
+++ b/devtools.js
@@ -1,5 +1,5 @@
 module.exports = function unistoreDevTools(store) {
-	var extension = window.devToolsExtension || window.top.devToolsExtension;
+	var extension = window.__REDUX_DEVTOOLS_EXTENSION__ || window.top.__REDUX_DEVTOOLS_EXTENSION__;
 	var ignoreState = false;
 
 	if (!extension) {


### PR DESCRIPTION
fixes: #69 

Move from `window.devToolsExtension` to `window.__REDUX_DEVTOOLS_EXTENSION__`

https://medium.com/@zalmoxis/redux-devtools-without-redux-or-how-to-have-a-predictable-state-with-any-architecture-61c5f5a7716f