### PR TITLE
Fix broken example in the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ let actions = store => ({
   // ... or just actions that call store.setState() later:
   incrementAsync(state) {
     setTimeout( () => {
-      store.setState({ count: state.count+1 })
+      store.setState({ count: store.getState().count+1 })
     }, 100)
   }
 })


### PR DESCRIPTION
In the example store.setState was called with what could be a stale state. In order to use the current state, one must call store.getState. Similar to how in React if you call setState without a callback it is a potential bug.