### PR TITLE
Types for connect class based components

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ store.setState({ a: 'b' });   // logs { a: 'b' }
 store.setState({ c: 'd' });   // logs { a: 'b', c: 'd' }
 ```
 
-Returns **[store](#store)**
+Returns **[store](#store)** 
 
 #### store
 
@@ -236,7 +236,7 @@ Generally, an entire application is wrapped in a single `<Provider>` at the root
 
 **Parameters**
 
-- `props` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)**
+- `props` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
     -   `props.store` **Store** A {Store} instance to expose via context.
 
 ### Reporting Issues

--- a/README.md
+++ b/README.md
@@ -1,10 +1,6 @@
-<p align="center">
-  <img src="https://i.imgur.com/o0u6dto.png" width="300" height="300" alt="unistore">
-  <br>
-  <a href="https://www.npmjs.org/package/unistore"><img src="https://img.shields.io/npm/v/unistore.svg?style=flat" alt="npm"></a> <a href="https://travis-ci.org/developit/unistore"><img src="https://travis-ci.org/developit/unistore.svg?branch=master" alt="travis"></a>
-</p>
+# unistore ... with modifications
 
-# unistore
+**NOTE**: This is a modified version of [Jason Miller's unistore package](https://github.com/developit/unistore). There have been a few improvements, but the vast majority of the code remains unchanged. These changes are awaiting approval, and I will abandon this repo once my changes are merged upstream.
 
 > A tiny ~650b centralized state container with component bindings for [Preact] & [React].
 
@@ -157,7 +153,7 @@ store.setState({ a: 'b' });   // logs { a: 'b' }
 store.setState({ c: 'd' });   // logs { a: 'b', c: 'd' }
 ```
 
-Returns **[store](#store)** 
+Returns **[store](#store)**
 
 #### store
 
@@ -240,7 +236,7 @@ Generally, an entire application is wrapped in a single `<Provider>` at the root
 
 **Parameters**
 
-- `props` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+- `props` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)**
     -   `props.store` **Store** A {Store} instance to expose via context.
 
 ### Reporting Issues
@@ -249,6 +245,8 @@ Found a problem? Want a new feature? First of all, see if your issue or idea has
 If not, just open a [new clear and descriptive issue](../../issues/new).
 
 ### License
+
+[MIT License](https://oss.ninja/mit?organization=Luke%20Lindsey) © Luke Lindsey
 
 [MIT License](https://oss.ninja/mit/developit) © [Jason Miller](https://jasonformat.com)
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 **NOTE**: This is a modified version of [Jason Miller's unistore package](https://github.com/developit/unistore). There have been a few improvements, but the vast majority of the code remains unchanged. These changes are awaiting approval, and I will abandon this repo once my changes are merged upstream.
 
+-----------------------------------
+
 > A tiny ~650b centralized state container with component bindings for [Preact] & [React].
 
 - **Small** footprint complements Preact nicely

--- a/index.d.ts
+++ b/index.d.ts
@@ -10,7 +10,7 @@ export type BoundAction = () => void;
 
 export interface Store<K> {
 	action(action: Action<K>): BoundAction;
-	setState(update: object, overwrite?: boolean, action?: Action<K>): void;
+	setState<U extends keyof K>(update: Pick<K, U>, overwrite?: boolean, action?: Action<K>): void;
 	subscribe(f: Listener<K>): Unsubscribe;
 	unsubscribe(f: Listener<K>): void;
 	getState(): K;

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "fixreadme": "node -e 'var fs=require(\"fs\");fs.writeFileSync(\"README.md\", fs.readFileSync(\"README.md\", \"utf8\").replace(/^-   /gm, \"- \"))'",
     "test": "eslint src && npm run build && jest",
     "prepare": "npm t",
-    "release": "npm t && git commit -am $npm_package_version && git tag $npm_package_version && git push && git push --tags && npm publish --access=public"
+    "release": "npm t && git commit -am luke-$npm_package_version && git tag luke-$npm_package_version && git push && git push --tags && npm publish --access=public"
   },
   "eslintConfig": {
     "extends": "eslint-config-developit",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "fixreadme": "node -e 'var fs=require(\"fs\");fs.writeFileSync(\"README.md\", fs.readFileSync(\"README.md\", \"utf8\").replace(/^-   /gm, \"- \"))'",
     "test": "eslint src && npm run build && jest",
     "prepare": "npm t",
-    "release": "npm t && git commit -am $npm_package_version && git tag $npm_package_version && git push && git push --tags && npm publish"
+    "release": "npm t && git commit -am $npm_package_version && git tag $npm_package_version && git push && git push --tags && npm publish --access=public"
   },
   "eslintConfig": {
     "extends": "eslint-config-developit",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "bundlesize": [
     {
       "path": "full/preact.js",
-      "maxSize": "750b"
+      "maxSize": "760b"
     },
     {
       "path": "dist/unistore.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lukelindsey/unistore",
-  "version": "3.0.6.1",
+  "version": "3.0.6-rc.1",
   "description": "Luke modified version of unistore package.",
   "source": "src/index.js",
   "module": "dist/unistore.es.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "unistore",
+  "name": "@lukelindsey/unistore",
   "version": "3.0.6",
-  "description": "Dead simple centralized state container (store) with preact and react bindings.",
+  "description": "Luke modified version of unistore package.",
   "source": "src/index.js",
   "module": "dist/unistore.es.js",
   "main": "dist/unistore.js",
@@ -59,6 +59,9 @@
       ]
     ]
   },
+  "jest": {
+    "testURL": "http://localhost"
+  },
   "files": [
     "src",
     "dist",
@@ -78,8 +81,8 @@
     "state machine",
     "redux"
   ],
-  "repository": "developit/unistore",
-  "author": "Jason Miller <jason@developit.ca>",
+  "repository": "LukeLindsey/unistore",
+  "author": "Luke Lindsey <luke.lindsey.dev@gmail.com>",
   "license": "MIT",
   "devDependencies": {
     "babel-jest": "^21.2.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "fixreadme": "node -e 'var fs=require(\"fs\");fs.writeFileSync(\"README.md\", fs.readFileSync(\"README.md\", \"utf8\").replace(/^-   /gm, \"- \"))'",
     "test": "eslint src && npm run build && jest",
     "prepare": "npm t",
-    "release": "npm t && git commit -am luke-$npm_package_version && git tag luke-$npm_package_version && git push && git push --tags && npm publish --access=public"
+    "release": "npm t && git tag luke-$npm_package_version && git push && git push --tags && npm publish --access=public"
   },
   "eslintConfig": {
     "extends": "eslint-config-developit",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lukelindsey/unistore",
-  "version": "3.0.6",
+  "version": "3.0.6.1",
   "description": "Luke modified version of unistore package.",
   "source": "src/index.js",
   "module": "dist/unistore.es.js",

--- a/preact.d.ts
+++ b/preact.d.ts
@@ -3,14 +3,14 @@
 // K - Store state
 // I - Injected props to wrapped component
 
-declare module "unistore/preact" {
+declare module "@lukelindsey/unistore/preact" {
 	import * as Preact from "preact";
-	import { ActionCreator, StateMapper, Store } from "unistore";
+	import { ActionCreator, StateMapper, Store } from "@lukelindsey/unistore";
 
 	export function connect<T, S, K, I>(
 		mapStateToProps: string | Array<string> | StateMapper<T, K, I>,
 		actions?: ActionCreator<K> | object
-	): (Child: ((props: T & I) => Preact.VNode) | Preact.ComponentConstructor<T&I, S>) => Preact.ComponentConstructor<T, S>;
+	): (Child: ((props: T & I) => Preact.VNode) | Preact.ComponentConstructor<T & I, S>) => Preact.ComponentConstructor<T, S>;
 
 	export interface ProviderProps<T> {
 		store: Store<T>;

--- a/preact.d.ts
+++ b/preact.d.ts
@@ -10,7 +10,7 @@ declare module "unistore/preact" {
 	export function connect<T, S, K, I>(
 		mapStateToProps: string | Array<string> | StateMapper<T, K, I>,
 		actions?: ActionCreator<K> | object
-	): (Child: (props: T & I) => Preact.VNode) => Preact.ComponentConstructor<T, S>;
+	): (Child: ((props: T & I) => Preact.VNode) | Preact.ComponentConstructor<T&I, S>) => Preact.ComponentConstructor<T, S>;
 
 	export interface ProviderProps<T> {
 		store: Store<T>;

--- a/react.d.ts
+++ b/react.d.ts
@@ -3,9 +3,9 @@
 // K - Store state
 // I - Injected props to wrapped component
 
-declare module "unistore/react" {
+declare module "@lukelindsey/unistore/react" {
 	import * as React from "react";
-	import { ActionCreator, StateMapper, Store } from "unistore";
+	import { ActionCreator, StateMapper, Store } from "@lukelindsey/unistore";
 
 	export function connect<T, S, K, I>(
 		mapStateToProps: string | Array<string> | StateMapper<T, K, I>,

--- a/src/integrations/preact.js
+++ b/src/integrations/preact.js
@@ -41,7 +41,7 @@ export function connect(mapStateToProps, actions) {
 			this.componentWillUnmount = () => {
 				store.unsubscribe(update);
 			};
-			this.render = props => h(Child, assign(assign(assign({}, boundActions), props), state));
+			this.render = props => h(Child, assign(assign(assign({ ref: (child) => { this.child = child; } }, boundActions), props), state));
 		}
 		return (Wrapper.prototype = new Component()).constructor = Wrapper;
 	};


### PR DESCRIPTION
Fixes an issue where typescript won't allow connecting a class based component as the types were written only for SFC. Example error is below.

`Argument of type 'typeof MyClassBasedComponent' is not assignable to parameter of type '(props: OwnProps & PropsFromStore) => VNode<any>'.
  Type 'typeof MyClassBasedComponent' provides no match for the signature '(props: OwnProps & PropsFromStore): VNode<any>'.`