### PR TITLE
Fixes for #97 and #103 `react.d.ts` needs to be updated

### DIFF
--- a/react.d.ts
+++ b/react.d.ts
@@ -16,7 +16,7 @@ declare module "unistore/react" {
 		store: Store<T>;
 	}
 
-	export class Provider<T> extends Component<ProviderProps<T>, {}> {
+	export class Provider<T> extends React.Component<ProviderProps<T>, {}> {
 		render(): React.ReactNode;
 	}
 }

--- a/react.d.ts
+++ b/react.d.ts
@@ -10,7 +10,7 @@ declare module "unistore/react" {
 	export function connect<T, S, K, I>(
 		mapStateToProps: string | Array<string> | StateMapper<T, K, I>,
 		actions?: ActionCreator<K> | object
-	): (Child: (props: T & I) => React.ReactNode) => React.Component<T, S>;
+	): (Child: ((props: T & I) => React.ReactNode) | (ComponentConstructor<T, S>)) => ComponentConstructor<T, S>;
 
 	export interface ProviderProps<T> {
 		store: Store<T>;
@@ -18,5 +18,9 @@ declare module "unistore/react" {
 
 	export class Provider<T> extends React.Component<ProviderProps<T>, {}> {
 		render(): React.ReactNode;
+	}
+	
+	interface ComponentConstructor<P = {}, S = {}> {
+		new(props: P, context?: any): React.Component<P, S>;
 	}
 }


### PR DESCRIPTION
As `React` is being imported as `import * as React from "react";` So `extends Component` will give reference error in Typescript. The correct way to refer is by `React.Component`