### PR TITLE
Add TypeScript support for connecting class based components.

### DIFF
--- a/preact.d.ts
+++ b/preact.d.ts
@@ -10,7 +10,7 @@ declare module "unistore/preact" {
 	export function connect<T, S, K, I>(
 		mapStateToProps: string | Array<string> | StateMapper<T, K, I>,
 		actions?: ActionCreator<K> | object
-	): (Child: (props: T & I) => Preact.VNode) => Preact.ComponentConstructor<T, S>;
+	): (Child: ((props: T & I) => Preact.VNode) | Preact.ComponentConstructor<T & I, S>) => Preact.ComponentConstructor<T, S>;
 
 	export interface ProviderProps<T> {
 		store: Store<T>;

--- a/react.d.ts
+++ b/react.d.ts
@@ -10,7 +10,7 @@ declare module "unistore/react" {
 	export function connect<T, S, K, I>(
 		mapStateToProps: string | Array<string> | StateMapper<T, K, I>,
 		actions?: ActionCreator<K> | object
-	): (Child: (props: T & I) => React.ReactNode) => React.Component<T, S>;
+	): (Child: ((props: T & I) => React.ReactNode) | React.Component<T, S>) => React.Component<T, S>;
 
 	export interface ProviderProps<T> {
 		store: Store<T>;


### PR DESCRIPTION
Fixes an issue where typescript won't allow connecting a class based component as the types were written only for SFC. Example error is below.

Argument of type 'typeof MyClassBasedComponent' is not assignable to parameter of type '(props: OwnProps & PropsFromStore) => VNode<any>'. Type 'typeof MyClassBasedComponent' provides no match for the signature '(props: OwnProps & PropsFromStore): VNode<any>'.