### PR TITLE
removed update from componentDidMount to prevent double connect call.

### DIFF
--- a/src/integrations/preact.js
+++ b/src/integrations/preact.js
@@ -35,7 +35,6 @@ export function connect(mapStateToProps, actions) {
 				}
 			};
 			this.componentDidMount = () => {
-				update();
 				store.subscribe(update);
 			};
 			this.componentWillUnmount = () => {

--- a/src/integrations/react.js
+++ b/src/integrations/react.js
@@ -40,7 +40,6 @@ export function connect(mapStateToProps, actions) {
 				}
 			};
 			this.componentDidMount = () => {
-				update();
 				store.subscribe(update);
 			};
 			this.componentWillUnmount = () => {


### PR DESCRIPTION
The state is already getting set here https://github.com/developit/unistore/blob/master/src/integrations/preact.js#L24 and here https://github.com/developit/unistore/blob/master/src/integrations/react.js#L29.  So calling `update()` in `componentDidMount` is redundant and causing `connect` to be triggered twice on mount.