### PR TITLE
Add devtools typings

### DIFF
--- a/devtools.d.ts
+++ b/devtools.d.ts
@@ -1,3 +1,3 @@
 import { Store } from "unistore";
 
-export default function unistoreDevTools<K>(state?: K): Store<K>;
+export default function unistoreDevTools<K>(store: Store<K>): Store<K>;

--- a/devtools.d.ts
+++ b/devtools.d.ts
@@ -1,0 +1,3 @@
+import { Store } from "unistore";
+
+export default function unistoreDevTools<K>(state?: K): Store<K>;


### PR DESCRIPTION
Due that Typescript threw me a `No declaration file was found for the 'unistore/devtools' module` error. This PR fixes it by just adding a `devtools.d.ts` file.

`"unistore": "^3.0.6"`

```ts
// store.ts
import createStore, { Store } from 'unistore'
import devtools from 'unistore/devtools'

// just like createStore() typing, devtools() will return the `State`
export const store = devtools(createStore({ count: 0 }))
// ...
```