### PR TITLE
 Added generics for state of component in preact.d.ts

### DIFF
--- a/preact.d.ts
+++ b/preact.d.ts
@@ -7,18 +7,17 @@ declare module "unistore/preact" {
 	import * as Preact from "preact";
 	import { ActionCreator, StateMapper, Store } from "unistore";
 
-	export function connect<T, K, I>(
+	export function connect<T, S, K, I>(
 		mapStateToProps: string | Array<string> | StateMapper<T, K, I>,
 		actions?: ActionCreator<K> | object
-	): (
-		Child: ((props?: T & I) => JSX.Element) | Preact.ComponentConstructor<T & I> | Preact.AnyComponent<T & I>
-	) => Preact.ComponentConstructor<T>;
+	): (Child: Preact.ComponentConstructor<T & I, S> | Preact.AnyComponent<T & I, S>) => Preact.ComponentConstructor<T, S>;
+
 
 	export interface ProviderProps<T> {
 		store: Store<T>;
 	}
 
 	export class Provider<T> extends Preact.Component<ProviderProps<T>> {
-		render(props: ProviderProps<T>): JSX.Element;
+		render(props: ProviderProps<T>): Preact.VNode;
 	}
 }


### PR DESCRIPTION

#There is requirement for generic for the "State" of a component which is added. 
#Preact is using Preact.VNode in place of JSX.element which is used by react.