### PR TITLE
Update react.js to use forceUpdate as default

### DIFF
--- a/src/integrations/react.js
+++ b/src/integrations/react.js
@@ -38,6 +38,7 @@ export function connect(mapStateToProps, actions) {
 					state = mapped;
 					return this.forceUpdate();
 				}
+		                return this.forceUpdate();
 			};
 			this.componentDidMount = () => {
 				store.subscribe(update);


### PR DESCRIPTION
Hey @developit I have run into cases that `connect`ed components wont work as expected (also seen this happening to a lot of ppl using react) I've found that the problem seems to be that it just doesn't get in to the first two `forceUpdate` I have added one more and seems to fix my problem (although idk if im updating by default) but for now seems to be solving my issue, just putting this out there. Let me know your thoughts 