### PR TITLE
Update ts definition for BoundAction to allow arguments

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -6,7 +6,7 @@
 export type Listener<K> = (state: K, action?: Action<K>) => void;
 export type Unsubscribe = () => void;
 export type Action<K> = (state: K, ...args: any[]) => void;
-export type BoundAction = () => void;
+export type BoundAction = (...args: any[]) => void;
 
 export interface Store<K> {
 	action(action: Action<K>): BoundAction;


### PR DESCRIPTION
Just a minor typings update.

The current definition of `BoundAction` says that it takes no arguments. `BoundAction` is just an action though, and they _do_ take arguments. Specifically where specified below. 

https://github.com/developit/unistore/blob/1df7cf60ac6fa1a70859d745fbaea7ea3f1b8d30/src/index.js#L58-L60