### PR TITLE
[TypeScript] Fix & improve actions in ActionCreator

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -18,7 +18,7 @@ export interface Store<K> {
 
 export default function createStore<K>(state?: K): Store<K>;
 
-export type ActionFn<K> = (state: K, ...args: any[]) => Partial<K> | void;
+export type ActionFn<K> = (state: K, ...args: any[]) => Promise<Partial<K>> | Partial<K> | void;
 
 export interface ActionMap<K> {
 	[actionName: string]: ActionFn<K>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -18,7 +18,7 @@ export interface Store<K> {
 
 export default function createStore<K>(state?: K): Store<K>;
 
-export type ActionFn<K> = (state: K) => object;
+export type ActionFn<K> = (state: K, ...args: any[]) => Partial<K> | void;
 
 export interface ActionMap<K> {
 	[actionName: string]: ActionFn<K>;


### PR DESCRIPTION
When writing the function that creates the actions object, with TypeScript, the definitions prohibit the actions from taking any parameters.

This new `d.ts` also types the return value of actions to be a subset of the Store state type, and also permits use of async functions.