### PR TITLE
Make react and preact peerDependencies both optional 

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "strip-json-comments-cli": "^1.0.1"
   },
   "peerDependencies": {
-    "preact": "*",
-    "react": "*"
+    "preact": "optional:*",
+    "react": "optional:*"
   }
 }


### PR DESCRIPTION
This avoids misleading npm warnings. Fixes #139.
/cc @Timer @NathanielHill