### PR TITLE
Use newer optional peer dependencies RFC

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,7 +106,15 @@
     "strip-json-comments-cli": "^1.0.1"
   },
   "peerDependencies": {
-    "preact": "optional:*",
-    "react": "optional:*"
+    "preact": "*",
+    "react": "*"
+  },
+  "peerDependenciesMeta": {
+    "preact": {
+      "optional": true
+    },
+    "react": {
+      "optional": true
+    }
   }
 }


### PR DESCRIPTION
The behavior was changed before the final implementation was made. Sorry I didn't catch this in my original issue.

See https://github.com/yarnpkg/rfcs/blob/master/accepted/0000-optional-peer-dependencies.md#2-detailed-design for usage.