### PR TITLE
Update preact bindings for Preact X

### DIFF
--- a/src/integrations/preact.js
+++ b/src/integrations/preact.js
@@ -1,4 +1,4 @@
-import { h, Component } from 'preact';
+import { h, Component, toChildArray } from 'preact';
 import { assign, mapActions, select } from '../util';
 
 /**
@@ -60,4 +60,4 @@ export function connect(mapStateToProps, actions) {
 export function Provider(props) {
 	this.getChildContext = () => ({ store: props.store });
 }
-Provider.prototype.render = props => props.children[0];
+Provider.prototype.render = props => toChildArray(props.children)[0];

--- a/src/integrations/preact.js
+++ b/src/integrations/preact.js
@@ -1,4 +1,4 @@
-import { h, Component, toChildArray } from 'preact';
+import { h, Component } from 'preact';
 import { assign, mapActions, select } from '../util';
 
 /**
@@ -60,4 +60,4 @@ export function connect(mapStateToProps, actions) {
 export function Provider(props) {
 	this.getChildContext = () => ({ store: props.store });
 }
-Provider.prototype.render = props => toChildArray(props.children)[0];
+Provider.prototype.render = props => Array.isArray(props.children) ? props.children[0] : props.children;


### PR DESCRIPTION
Backwards compatible fix for calling the only child.

Your call if you want to drop support for `< Preact X` and just use `props.children` straight up