### PR TITLE
Update preact typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -26,4 +26,4 @@ export interface ActionMap<K> {
 
 export type ActionCreator<K> = (store: Store<K>) => ActionMap<K>;
 
-export type StateMapper<T, K, I> = (state: K, props: T) => I;
+export type StateMapper<T, K, I> = (state: K, props: T) => Partial<I>;

--- a/preact.d.ts
+++ b/preact.d.ts
@@ -10,7 +10,7 @@ declare module "unistore/preact" {
 	export function connect<T, S, K, I>(
 		mapStateToProps: string | Array<string> | StateMapper<T, K, I>,
 		actions?: ActionCreator<K> | object
-	): (Child: Preact.ComponentConstructor<T & I, S> | Preact.AnyComponent<T & I, S>) => Preact.ComponentConstructor<T, S>;
+	): <C>(Child: Preact.ComponentConstructor<T & I, S> | Preact.AnyComponent<T & I, S>) => C extends Preact.AnyComponent<T & I, S> ? C : never;
 
 
 	export interface ProviderProps<T> {


### PR DESCRIPTION
Previously, if was difficult to correctly match the output from connect to the wrapped child component.

This ensures that the returned type from the decorator is the same as the passed in type. Previously errors were prevalent with `typeof MyComponent is not equivalent to Preact.ComponentConstructor`