### PR TITLE
Fix JSX now namespaced (preact-X)

### DIFF
--- a/preact.d.ts
+++ b/preact.d.ts
@@ -18,6 +18,6 @@ declare module "unistore/preact" {
 	}
 
 	export class Provider<T> extends Preact.Component<ProviderProps<T>> {
-		render(props: ProviderProps<T>): JSX.Element;
+		render(props: ProviderProps<T>): Preact.JSX.Element;
 	}
 }


### PR DESCRIPTION
As of preact X, JSX is now namespaced under preact. Updated the typings to reflect this change.