### PR TITLE
Mutations

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,8 +154,8 @@ Creates a new store, which is a tiny evented state container.
 ```javascript
 let store = createStore();
 store.subscribe( state => console.log(state) );
-store.setState({ a: 'b' });	// logs { a: 'b' }
-store.setState({ c: 'd' });	// logs { a: 'b', c: 'd' }
+store.setState({ a: 'b' });   // logs { a: 'b' }
+store.setState({ c: 'd' });   // logs { a: 'b', c: 'd' }
 ```
 
 Returns **[store](#store)** 

--- a/README.md
+++ b/README.md
@@ -147,6 +147,8 @@ Creates a new store, which is a tiny evented state container.
 **Parameters**
 
 - `state` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** Optional initial state (optional, default `{}`)
+- `mutations`  
+- `sync`  
 
 **Examples**
 

--- a/README.md
+++ b/README.md
@@ -148,7 +148,6 @@ Creates a new store, which is a tiny evented state container.
 
 - `state` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** Optional initial state (optional, default `{}`)
 - `mutations`  
-- `sync`  
 
 **Examples**
 

--- a/README.md
+++ b/README.md
@@ -147,15 +147,15 @@ Creates a new store, which is a tiny evented state container.
 **Parameters**
 
 - `state` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** Optional initial state (optional, default `{}`)
-- `mutations`  
+- `mutations`   (optional, default `false`)
 
 **Examples**
 
 ```javascript
 let store = createStore();
 store.subscribe( state => console.log(state) );
-store.setState({ a: 'b' });   // logs { a: 'b' }
-store.setState({ c: 'd' });   // logs { a: 'b', c: 'd' }
+store.setState({ a: 'b' });	// logs { a: 'b' }
+store.setState({ c: 'd' });	// logs { a: 'b', c: 'd' }
 ```
 
 Returns **[store](#store)** 

--- a/package.json
+++ b/package.json
@@ -28,11 +28,11 @@
   "bundlesize": [
     {
       "path": "full/preact.js",
-      "maxSize": "823b"
+      "maxSize": "817b"
     },
     {
       "path": "dist/unistore.js",
-      "maxSize": "423b"
+      "maxSize": "414b"
     },
     {
       "path": "preact.js",

--- a/package.json
+++ b/package.json
@@ -28,11 +28,11 @@
   "bundlesize": [
     {
       "path": "full/preact.js",
-      "maxSize": "818b"
+      "maxSize": "819b"
     },
     {
       "path": "dist/unistore.js",
-      "maxSize": "412b"
+      "maxSize": "417b"
     },
     {
       "path": "preact.js",

--- a/package.json
+++ b/package.json
@@ -28,11 +28,11 @@
   "bundlesize": [
     {
       "path": "full/preact.js",
-      "maxSize": "813b"
+      "maxSize": "838b"
     },
     {
       "path": "dist/unistore.js",
-      "maxSize": "411b"
+      "maxSize": "439b"
     },
     {
       "path": "preact.js",

--- a/package.json
+++ b/package.json
@@ -28,11 +28,11 @@
   "bundlesize": [
     {
       "path": "full/preact.js",
-      "maxSize": "838b"
+      "maxSize": "818b"
     },
     {
       "path": "dist/unistore.js",
-      "maxSize": "439b"
+      "maxSize": "412b"
     },
     {
       "path": "preact.js",

--- a/package.json
+++ b/package.json
@@ -28,11 +28,11 @@
   "bundlesize": [
     {
       "path": "full/preact.js",
-      "maxSize": "760b"
+      "maxSize": "823b"
     },
     {
       "path": "dist/unistore.js",
-      "maxSize": "400b"
+      "maxSize": "423b"
     },
     {
       "path": "preact.js",

--- a/package.json
+++ b/package.json
@@ -28,11 +28,11 @@
   "bundlesize": [
     {
       "path": "full/preact.js",
-      "maxSize": "817b"
+      "maxSize": "813b"
     },
     {
       "path": "dist/unistore.js",
-      "maxSize": "414b"
+      "maxSize": "411b"
     },
     {
       "path": "preact.js",

--- a/src/index.js
+++ b/src/index.js
@@ -13,8 +13,7 @@ import { assign } from './util';
  */
 export default function createStore(state, mutations) {
 	let listeners = [];
-  state = state || {};
-  mutations = mutations;
+	state = state || {};
 
 	function unsubscribe(listener) {
 		let out = [];
@@ -29,17 +28,17 @@ export default function createStore(state, mutations) {
 		listeners = out;
 	}
 
-  function setState(update, overwrite, action) {
+	function setState(update, overwrite, action) {
 		state = overwrite ? update : assign(assign({}, state), update);
-    let currentListeners = listeners;
-    for (let i=0; i<currentListeners.length; i++) currentListeners[i](state, update, overwrite, action);
-  }
+		let currentListeners = listeners;
+		for (let i=0; i<currentListeners.length; i++) currentListeners[i](state, update, overwrite, action);
+	}
 
 
-  function mutate(act, overwrite) {
-    let key = Object.keys(act)[0];
-    setState(mutations[key](state, ...act[key]), overwrite, act);
-  }
+	function mutate(act, overwrite) {
+		let key = Object.keys(act)[0];
+		setState(mutations[key](state, ...act[key]), overwrite, act);
+	}
 
 	/**
 	 * An observable state container, returned from {@link createStore}
@@ -56,11 +55,11 @@ export default function createStore(state, mutations) {
 		 * @returns {Function} boundAction()
 		 */
 		action(action) {
-      function apply(act) {
-        if (mutations)
-          mutate(act)
-        else
-          setState(act, false);
+			function apply(act) {
+				if (mutations)
+					mutate(act);
+				else
+					setState(act, false);
 			}
 
 			// Note: perf tests verifying this implementation: https://esbench.com/bench/5a295e6299634800a0349500
@@ -69,7 +68,7 @@ export default function createStore(state, mutations) {
 				for (let i=0; i<arguments.length; i++) args.push(arguments[i]);
 				let ret = action.apply(this, args);
 				if (ret!=null) {
-					if (ret.then) return ret.then(apply)
+					if (ret.then) return ret.then(apply);
 					return apply(ret);
 				}
 			};
@@ -80,9 +79,9 @@ export default function createStore(state, mutations) {
 		 * @param {Object} update				An object with properties to be merged into state
 		 * @param {Boolean} [overwrite=false]	If `true`, update will replace state instead of being merged into it
 		 */
-    setState,
+		setState,
 
-    mutate,
+		mutate,
 
 		/**
 		 * Register a listener function to be called whenever state is changed. Returns an `unsubscribe()` function.

--- a/src/index.js
+++ b/src/index.js
@@ -8,10 +8,10 @@ import { assign } from './util';
  * @example
  * let store = createStore();
  * store.subscribe( state => console.log(state) );
- * store.setState({ a: 'b' });   // logs { a: 'b' }
- * store.setState({ c: 'd' });   // logs { a: 'b', c: 'd' }
+ * store.setState({ a: 'b' });	// logs { a: 'b' }
+ * store.setState({ c: 'd' });	// logs { a: 'b', c: 'd' }
  */
-export default function createStore(state, mutations) {
+export default function createStore(state, mutations=false) {
 	let listeners = [];
 	state = state || {};
 
@@ -31,13 +31,16 @@ export default function createStore(state, mutations) {
 	function setState(update, overwrite, action) {
 		state = overwrite ? update : assign(assign({}, state), update);
 		let currentListeners = listeners;
-		for (let i=0; i<currentListeners.length; i++) currentListeners[i](state, update, overwrite, action);
+		if (mutations)
+			for (let i=0; i<currentListeners.length; i++) currentListeners[i](state, update, action);
+		else
+			for (let i=0; i<currentListeners.length; i++) currentListeners[i](state, update);
+
 	}
 
-
-	function mutate(act, overwrite) {
-		let key = Object.keys(act)[0];
-		setState(mutations[key](state, act[key]), overwrite, act);
+	function mutate(action, overwrite) {
+		const key = Object.keys(action)[0];
+		setState(mutations[key](state, action[key]), overwrite, action);
 	}
 
 	/**
@@ -55,11 +58,11 @@ export default function createStore(state, mutations) {
 		 * @returns {Function} boundAction()
 		 */
 		action(action) {
-			function apply(act) {
+			function apply(result) {
 				if (mutations)
-					mutate(act);
+					mutate(result, false);
 				else
-					setState(act, false);
+					setState(result, false, action);
 			}
 
 			// Note: perf tests verifying this implementation: https://esbench.com/bench/5a295e6299634800a0349500

--- a/src/index.js
+++ b/src/index.js
@@ -31,11 +31,7 @@ export default function createStore(state, mutations=false) {
 	function setState(update, overwrite, action) {
 		state = overwrite ? update : assign(assign({}, state), update);
 		let currentListeners = listeners;
-		if (mutations)
-			for (let i=0; i<currentListeners.length; i++) currentListeners[i](state, update, action);
-		else
-			for (let i=0; i<currentListeners.length; i++) currentListeners[i](state, update);
-
+		for (let i=0; i<currentListeners.length; i++) currentListeners[i](state, action);
 	}
 
 	function mutate(action, overwrite) {
@@ -59,10 +55,7 @@ export default function createStore(state, mutations=false) {
 		 */
 		action(action) {
 			function apply(result) {
-				if (mutations)
-					mutate(result, false);
-				else
-					setState(result, false, action);
+				setState(result, false, action);
 			}
 
 			// Note: perf tests verifying this implementation: https://esbench.com/bench/5a295e6299634800a0349500

--- a/src/index.js
+++ b/src/index.js
@@ -37,7 +37,7 @@ export default function createStore(state, mutations) {
 
 	function mutate(act, overwrite) {
 		let key = Object.keys(act)[0];
-		setState(mutations[key](state, ...act[key]), overwrite, act);
+		setState(mutations[key](state, act[key]), overwrite, act);
 	}
 
 	/**

--- a/src/index.js
+++ b/src/index.js
@@ -55,7 +55,10 @@ export default function createStore(state, mutations=false) {
 		 */
 		action(action) {
 			function apply(result) {
-				setState(result, false, action);
+				if (!mutations)
+					setState(result, false, action);
+				else
+					mutate(result, false);
 			}
 
 			// Note: perf tests verifying this implementation: https://esbench.com/bench/5a295e6299634800a0349500

--- a/src/index.js
+++ b/src/index.js
@@ -8,8 +8,8 @@ import { assign } from './util';
  * @example
  * let store = createStore();
  * store.subscribe( state => console.log(state) );
- * store.setState({ a: 'b' });	// logs { a: 'b' }
- * store.setState({ c: 'd' });	// logs { a: 'b', c: 'd' }
+ * store.setState({ a: 'b' });   // logs { a: 'b' }
+ * store.setState({ c: 'd' });   // logs { a: 'b', c: 'd' }
  */
 export default function createStore(state, mutations=false) {
 	let listeners = [];

--- a/src/index.js
+++ b/src/index.js
@@ -11,11 +11,10 @@ import { assign } from './util';
  * store.setState({ a: 'b' });   // logs { a: 'b' }
  * store.setState({ c: 'd' });   // logs { a: 'b', c: 'd' }
  */
-export default function createStore(state, mutations, sync) {
+export default function createStore(state, mutations) {
 	let listeners = [];
   state = state || {};
   mutations = mutations;
-  sync = sync || undefined;
 
 	function unsubscribe(listener) {
 		let out = [];

--- a/test/unistore.test.js
+++ b/test/unistore.test.js
@@ -37,27 +37,27 @@ describe('createStore()', () => {
 		expect(rval).toBeInstanceOf(Function);
 
 		store.setState({ a: 'b' });
-		expect(sub1).toBeCalledWith(store.getState(), { a: 'b' });
+		expect(sub1).toBeCalledWith(store.getState(), action);
 
 		store.subscribe(sub2);
 		store.setState({ c: 'd' });
 
 		expect(sub1).toHaveBeenCalledTimes(2);
-		expect(sub1).toHaveBeenLastCalledWith(store.getState(), { c: 'd' });
-		expect(sub2).toBeCalledWith(store.getState(), { c: 'd' });
-    });
+		expect(sub1).toHaveBeenLastCalledWith(store.getState(), action);
+		expect(sub2).toBeCalledWith(store.getState(), action);
+	});
 
-    it('should invoke subscriptions passing additional action parameter when using mutations', () => {
-        let store = createStore({ foo: 0 }, {
+	it('should invoke subscriptions passing additional action parameter when using mutations', () => {
+		let store = createStore({ foo: 0 }, {
 			setFoo: (state, {v}) => ({ foo: v }),
 		})
 
-        let sub = jest.fn();
-        let rval = store.subscribe(sub);
+		let sub = jest.fn();
+		let rval = store.subscribe(sub);
 
-        store.mutate({ setFoo: { v: 1 } });
-        expect(sub).toBeCalledWith(store.getState(), { foo: 1 }, { setFoo: { v: 1 } })
-     });
+		store.mutate({ setFoo: { v: 1 } });
+		expect(sub).toBeCalledWith(store.getState(), { setFoo: { v: 1 } })
+	});
 
 	it('should unsubscribe', () => {
 		let store = createStore();

--- a/test/unistore.test.js
+++ b/test/unistore.test.js
@@ -114,5 +114,5 @@ describe('createStore()', () => {
 
 		store.mutate({ setFoo: { v: 1 } })
 		expect(store.getState()).toMatchObject({ foo: 1 })
-	 });
+     });
 });

--- a/test/unistore.test.js
+++ b/test/unistore.test.js
@@ -47,7 +47,7 @@ describe('createStore()', () => {
 		expect(sub2).toBeCalledWith(store.getState(), action);
 	});
 
-	it('should invoke subscriptions passing additional action parameter when using mutations', () => {
+	it('should invoke subscriptions using mutations', () => {
 		let store = createStore({ foo: 0 }, {
 			setFoo: (state, {v}) => ({ foo: v }),
 		})

--- a/test/unistore.test.js
+++ b/test/unistore.test.js
@@ -93,5 +93,14 @@ describe('createStore()', () => {
 		expect(sub1).not.toBeCalled();
 		expect(sub2).not.toBeCalled();
 		expect(sub3).not.toBeCalled();
-	});
+    });
+
+    it('should allow mutations', () => {
+        let store = createStore({ foo: 0 }, {
+            setFoo: (state, {v}) => ({ foo: v }),
+        })
+
+        store.mutate({ setFoo: { v: 1 } })
+        expect(store.getState()).toMatchObject({ foo: 1 })
+    });
 });

--- a/test/unistore.test.js
+++ b/test/unistore.test.js
@@ -37,15 +37,27 @@ describe('createStore()', () => {
 		expect(rval).toBeInstanceOf(Function);
 
 		store.setState({ a: 'b' });
-		expect(sub1).toBeCalledWith(store.getState(), { a: 'b' }, undefined, undefined);
+		expect(sub1).toBeCalledWith(store.getState(), { a: 'b' });
 
 		store.subscribe(sub2);
 		store.setState({ c: 'd' });
 
 		expect(sub1).toHaveBeenCalledTimes(2);
-		expect(sub1).toHaveBeenLastCalledWith(store.getState(), { c: 'd' }, undefined, undefined);
-		expect(sub2).toBeCalledWith(store.getState(), { c: 'd' }, undefined, undefined);
-	});
+		expect(sub1).toHaveBeenLastCalledWith(store.getState(), { c: 'd' });
+		expect(sub2).toBeCalledWith(store.getState(), { c: 'd' });
+    });
+
+    it('should invoke subscriptions passing additional action parameter when using mutations', () => {
+        let store = createStore({ foo: 0 }, {
+			setFoo: (state, {v}) => ({ foo: v }),
+		})
+
+        let sub = jest.fn();
+        let rval = store.subscribe(sub);
+
+        store.mutate({ setFoo: { v: 1 } });
+        expect(sub).toBeCalledWith(store.getState(), { foo: 1 }, { setFoo: { v: 1 } })
+     });
 
 	it('should unsubscribe', () => {
 		let store = createStore();
@@ -93,14 +105,14 @@ describe('createStore()', () => {
 		expect(sub1).not.toBeCalled();
 		expect(sub2).not.toBeCalled();
 		expect(sub3).not.toBeCalled();
-    });
+	 });
 
-    it('should allow mutations', () => {
-        let store = createStore({ foo: 0 }, {
-            setFoo: (state, {v}) => ({ foo: v }),
-        })
+	 it('should allow mutations', () => {
+		let store = createStore({ foo: 0 }, {
+			setFoo: (state, {v}) => ({ foo: v }),
+		})
 
-        store.mutate({ setFoo: { v: 1 } })
-        expect(store.getState()).toMatchObject({ foo: 1 })
-    });
+		store.mutate({ setFoo: { v: 1 } })
+		expect(store.getState()).toMatchObject({ foo: 1 })
+	 });
 });

--- a/test/unistore.test.js
+++ b/test/unistore.test.js
@@ -37,14 +37,14 @@ describe('createStore()', () => {
 		expect(rval).toBeInstanceOf(Function);
 
 		store.setState({ a: 'b' });
-		expect(sub1).toBeCalledWith(store.getState(), action);
+		expect(sub1).toBeCalledWith(store.getState(), { a: 'b' }, undefined, undefined);
 
 		store.subscribe(sub2);
 		store.setState({ c: 'd' });
 
 		expect(sub1).toHaveBeenCalledTimes(2);
-		expect(sub1).toHaveBeenLastCalledWith(store.getState(), action);
-		expect(sub2).toBeCalledWith(store.getState(), action);
+		expect(sub1).toHaveBeenLastCalledWith(store.getState(), { c: 'd' }, undefined, undefined);
+		expect(sub2).toBeCalledWith(store.getState(), { c: 'd' }, undefined, undefined);
 	});
 
 	it('should unsubscribe', () => {


### PR DESCRIPTION
### A Mutation system for Unistore.

> I'm not convinced my self this should be merged in, as unused paradigm shouldn't be pushed in production. Here's the fork called [mutastore](https://github.com/krzepah/mutastore) ; It will all depend on your feedback.

## Introduction

**Why** : I wanted to bind a listener to the store to synchronise every state change online. As for today, we only retrieve updated state and the update that triggered this.

Now here lies the problem, when we use a list of elements, that update contains the entire list of elements;  So sending this trough was not really a good idea.

**What** : I needed to retrieve only the few parameters that were actually added to the store. Hence, the easiest way to achieve this was to change the actions so they don't return the update, but rather which mutation it should call and it's parameters.

## So what changed to be short ?

Listeners receive a "mutation command" rather than the full update

They are in the form 
```
{ 'mutationKey': {...params} }
```
The first key of the object is used a a mutation key, while it's data is used as args. Every other key is
used as an additional parameter to pass trough to the listeners.

Mutations are in the form

```
const mutations = {
  mutationKey: (state, {...params}) => ({...yourUsualDataMutation})
}
```

## Oh boy you want to break all of our apps ?

Mutation is an optional paradigm that is enabled only if a mutation parameter is sent to createStore.

Even if mutations are passed to the store, setState should work as intended as it received no change.

Unfortunately mutation usage is rather radical since any action return would then be considered as a mutation ; .setState can still be used to make a direct change in the store.

A new *mutate* function is also available, it can only work if a mutation object is passed to the store.

```
/**
 * Triggers a mutation
 * @param act is an object containing mutation key and it's params
 * @overwrite allow to overwrite the state by the mutation result
 */
function mutate(act, overwrite) {
	let key = Object.keys(act)[0];
	setState(mutations[key](state, act[key]), overwrite, act);
}
```

## Cost
full/preact.js : 760b to 818b = **58b**
full/unistore.js : 400b to 412b = **12b**
Total : **70b**


## Example
### Before
```
store.subscribe((state, action) => console.log(action))

const Base = < div>< /div>
const CBase = connect(
  (state, props) => {...state},
  (state, props) => {
     addElement: (state, e, id) => ({
       elements: merge(state.elements, {...e}),
       elementsIds: concat(state.elementsIds, id)
  }
)(Base)

```
##### Output

```
{ 
  elements: {
     a,
     ...
     z
   },
   elementsIds : [a...z]
}
```

### After
```
const mutations = {
  newElement: (state, {text, newId}) => ({
    elements: merge({
      [newId]: text
    }, state.elements),
    elementsIds: concat([newId], state.elementsIds)
  })
}

let store = createStore(defaults, mutations)

store.subscribe((state, action) => console.log(act))

const Base = < div>< /div>
const CBase = connect(
(state, props) => {...state},
  (state, props) => {
     addElement: (state, e, id) => { 'newElement': {...e, ...id} }
)(Base)

```

##### Output 
```
{ 'newElement': { 'text': 'foo', id: 'bar' } }
```