### PR TITLE
fix #171 - remove warnings about deprecated hook on react 16.9.0^

### DIFF
--- a/src/integrations/preact.js
+++ b/src/integrations/preact.js
@@ -35,7 +35,7 @@ export function connect(mapStateToProps, actions) {
 					return this.setState({});
 				}
 			};
-			this.UNSAFE_componentWillReceiveProps = p => {
+			this.componentWillReceiveProps = p => {
 				props = p;
 				update();
 			};

--- a/src/integrations/preact.js
+++ b/src/integrations/preact.js
@@ -35,7 +35,7 @@ export function connect(mapStateToProps, actions) {
 					return this.setState({});
 				}
 			};
-			this.componentWillReceiveProps = p => {
+			this.UNSAFE_componentWillReceiveProps = p => {
 				props = p;
 				update();
 			};

--- a/src/integrations/react.js
+++ b/src/integrations/react.js
@@ -39,7 +39,7 @@ export function connect(mapStateToProps, actions) {
 					return this.forceUpdate();
 				}
 			};
-			this.componentWillReceiveProps = p => {
+			this.UNSAFE_componentWillReceiveProps = p => {
 				props = p;
 				update();
 			};

--- a/src/integrations/react.js
+++ b/src/integrations/react.js
@@ -39,7 +39,7 @@ export function connect(mapStateToProps, actions) {
 					return this.forceUpdate();
 				}
 			};
-			this.getDerivedStateFromProps = p => {
+			this.UNSAFE_componentWillReceiveProps = p => {
 				props = p;
 				update();
 			};

--- a/src/integrations/react.js
+++ b/src/integrations/react.js
@@ -39,7 +39,7 @@ export function connect(mapStateToProps, actions) {
 					return this.forceUpdate();
 				}
 			};
-			this.UNSAFE_componentWillReceiveProps = p => {
+			this.getDerivedStateFromProps = p => {
 				props = p;
 				update();
 			};


### PR DESCRIPTION
This will fix issue with warnings.
Probably will be better migrate to getDerivedStateFromProps hook with null return, but I not sure how I can call static method it this case 