### PR TITLE
Update Preact X version to release

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "jest": "^24.3.1",
     "microbundle": "^0.11.0",
     "npm-run-all": "^4.1.2",
-    "preact": "^10.0.0-alpha.1",
+    "preact": "^10.0.0",
     "raf": "^3.4.0",
     "react": "^16.8.4",
     "react-dom": "^16.8.4",


### PR DESCRIPTION
unistore is currently using an alpha version of preact x; pull request to update to release version of preact x.