### PR TITLE
Micro-optimize action binding by preallocating arguments array

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "bundlesize": [
     {
       "path": "full/preact.js",
-      "maxSize": "760b"
+      "maxSize": "780b"
     },
     {
       "path": "dist/unistore.js",

--- a/src/index.js
+++ b/src/index.js
@@ -55,8 +55,9 @@ export default function createStore(state) {
 
 			// Note: perf tests verifying this implementation: https://esbench.com/bench/5a295e6299634800a0349500
 			return function() {
-				let args = [state];
-				for (let i=0; i<arguments.length; i++) args.push(arguments[i]);
+				let args = Array(arguments.length + 1);
+				args[0] = state;
+				for (let i=0; i<arguments.length; i++) args[i + 1] = arguments[i];
 				let ret = action.apply(this, args);
 				if (ret!=null) {
 					if (ret.then) return ret.then(apply);

--- a/src/index.js
+++ b/src/index.js
@@ -55,9 +55,10 @@ export default function createStore(state) {
 
 			// Note: perf tests verifying this implementation: https://esbench.com/bench/5a295e6299634800a0349500
 			return function() {
-				let args = Array(arguments.length + 1);
+				let i = arguments.length,
+					args = Array(arguments.length + 1);
 				args[0] = state;
-				for (let i=0; i<arguments.length; i++) args[i + 1] = arguments[i];
+				while (i) args[i--] = arguments[i];
 				let ret = action.apply(this, args);
 				if (ret!=null) {
 					if (ret.then) return ret.then(apply);


### PR DESCRIPTION
It doesn't seem I can easily edit or fork the [referenced benchmark](https://esbench.com/bench/5a295e6299634800a0349500), but in the latest Chrome (78), this appears to perform slightly better than the current implementation:

![image](https://user-images.githubusercontent.com/1779930/68361960-a09e4000-00f3-11ea-886f-215df2eedfdb.png)

<details>
<summary>Benchmark details</summary>
Setup:

```
const store7 = createStore();
let viaPreallocated = (function viaPreallocated(store, action) {
    return function() {
        let args = new Array(arguments.length + 1);
        args[0] = store.getState();
        for (let i=0; i<arguments.length; i++) args[i+1] = arguments[i];
        return a7(args);
    };
})(store7, 'viaPreallocated');
```

Test:

```
viaPreallocated('a');
viaPreallocated('b');
viaPreallocated(1, 2);
viaPreallocated({});
```
</details>

It's a technique we use in [our state library's selector binding](https://github.com/WordPress/gutenberg/blob/497b42bbfe3216c38181ec0a7221bbf449dd88a7/packages/data/src/namespace-store/index.js#L160-L176).

The size bump is bigger than expected, not significant, but enough to fail tests without adjusting the permitted bundle size.