### PR TITLE
Save 2 bytes

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -59,8 +59,7 @@ export default function createStore(state) {
 				for (let i=0; i<arguments.length; i++) args.push(arguments[i]);
 				let ret = action.apply(this, args);
 				if (ret!=null) {
-					if (ret.then) return ret.then(apply);
-					return apply(ret);
+					ret.then ? ret.then(apply) : apply(ret);
 				}
 			};
 		},


### PR DESCRIPTION
Before
```
 PASS  full/preact.js: 760B < maxSize 760B (gzip) 

 PASS  dist/unistore.js: 355B < maxSize 400B (gzip) 

 PASS  preact.js: 546B < maxSize 600B (gzip) 
```

After
```
 PASS  full/preact.js: 758B < maxSize 760B (gzip) 

 PASS  dist/unistore.js: 355B < maxSize 400B (gzip) 

 PASS  preact.js: 546B < maxSize 600B (gzip) 
```

This save 2 bytes.
BoundAction becomes returning void by this change.
It is breaking change.
But, BoundAction return void in type definition.
This behavior is not described  in document.

https://github.com/developit/unistore/blob/b08e0c5660b7141f2c0a92c668c2acb397bc527f/index.d.ts#L9
https://github.com/developit/unistore#action




