### PR TITLE
WIP Rethinking actions and action creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ Returns **[store](#store)**
 
 An observable state container, returned from [createStore](#createstore)
 
-##### action
+##### dispatch
 
 Create a bound copy of the given action function.
 The bound returned function invokes action() and persists the result back to the store.

--- a/devtools.js
+++ b/devtools.js
@@ -19,6 +19,7 @@ module.exports = function unistoreDevTools(store) {
 		});
 		store.devtools.init(store.getState());
 		store.subscribe(function (state, action, update) {
+			update = update || {};
 			var actionName = action
 				? action.type ||
 				  action.name ||

--- a/devtools.js
+++ b/devtools.js
@@ -18,11 +18,11 @@ module.exports = function unistoreDevTools(store) {
 			}
 		});
 		store.devtools.init(store.getState());
-		store.subscribe(function (state, action) {
+		store.subscribe(function (state, action, update) {
 			var actionName = action && (action.name || action.type) || 'setState';
 
 			if (!ignoreState) {
-				store.devtools.send(actionName, state);
+				store.devtools.send({ type: actionName, update: update }, state);
 			} else {
 				ignoreState = false;
 			}

--- a/devtools.js
+++ b/devtools.js
@@ -19,7 +19,7 @@ module.exports = function unistoreDevTools(store) {
 		});
 		store.devtools.init(store.getState());
 		store.subscribe(function (state, action) {
-			var actionName = action && action.name || 'setState';
+			var actionName = action && (action.name || action.type) || 'setState';
 
 			if (!ignoreState) {
 				store.devtools.send(actionName, state);

--- a/devtools.js
+++ b/devtools.js
@@ -19,7 +19,11 @@ module.exports = function unistoreDevTools(store) {
 		});
 		store.devtools.init(store.getState());
 		store.subscribe(function (state, action, update) {
-			var actionName = action ? action.type || action.name || 'Unnamed' : 'setState';
+			var actionName = action
+				? action.type ||
+				  action.name ||
+				  'N/A (' + (Object.keys(update).join(', ') || 'none') + ')'
+				: 'setState (' + (Object.keys(update).join(', ') || 'none') + ')';
 
 			if (!ignoreState) {
 				store.devtools.send({ type: actionName, update: update }, state);

--- a/devtools.js
+++ b/devtools.js
@@ -19,7 +19,7 @@ module.exports = function unistoreDevTools(store) {
 		});
 		store.devtools.init(store.getState());
 		store.subscribe(function (state, action, update) {
-			var actionName = action ? action.name || action.type || 'Unnamed' : 'setState';
+			var actionName = action ? action.type || action.name || 'Unnamed' : 'setState';
 
 			if (!ignoreState) {
 				store.devtools.send({ type: actionName, update: update }, state);

--- a/devtools.js
+++ b/devtools.js
@@ -19,7 +19,7 @@ module.exports = function unistoreDevTools(store) {
 		});
 		store.devtools.init(store.getState());
 		store.subscribe(function (state, action, update) {
-			var actionName = action && (action.name || action.type) || 'setState';
+			var actionName = action ? action.name || action.type || 'Unnamed' : 'setState';
 
 			if (!ignoreState) {
 				store.devtools.send({ type: actionName, update: update }, state);

--- a/index.d.ts
+++ b/index.d.ts
@@ -36,7 +36,7 @@ export type MappedActionCreators<A> = {
 
 
 export interface Store<K> {
-	action(action: Action<K>): Promise<void> | void;
+	dispatch(action: Action<K>): Promise<void> | void;
 	setState<U extends keyof K>(update: Pick<K, U>, overwrite?: boolean, action?: Action<K>): void;
 	subscribe(f: Listener<K>): Unsubscribe;
 	unsubscribe(f: Listener<K>): void;

--- a/index.d.ts
+++ b/index.d.ts
@@ -26,6 +26,15 @@ export type AsyncActionCreator<K> = (...args: any[]) => AsyncActionFn<K> | Async
 export type SyncActionCreator<K> = (...args: any[]) => SyncActionFn<K> | SyncActionObject<K>;
 export type ActionCreator<K> = AsyncActionCreator<K> | SyncActionCreator<K>;
 
+export type ActionCreatorsObject<K> = {
+  [actionCreator: string]: ActionCreator<K>
+}
+
+export type MappedActionCreators<A> = {
+  [P in keyof A]: A[P] extends AsyncActionCreator<any> ? (...args: any[]) => Promise<void> : (...args: any[]) => void
+}
+
+
 export interface Store<K> {
 	action(action: Action<K>): Promise<void> | void;
 	setState<U extends keyof K>(update: Pick<K, U>, overwrite?: boolean, action?: Action<K>): void;
@@ -35,9 +44,5 @@ export interface Store<K> {
 }
 
 export default function createStore<K>(state?: K): Store<K>;
-
-export interface ActionMap<K> {
-	[actionName: string]: ActionCreator<K>;
-}
 
 export type StateMapper<T, K, I> = (state: K, props: T) => I;

--- a/index.d.ts
+++ b/index.d.ts
@@ -3,7 +3,7 @@
 // K - Store state
 // I - Injected props to wrapped component
 
-export type Listener<K> = (state: K, action?: Action<K>) => void;
+export type Listener<K> = (state: K, action?: Action<K>, update?: Partial<K>) => void;
 export type Unsubscribe = () => void;
 export type ActionFn<K> = (state: K, store: Store<K>) => Promise<Partial<K>> | Partial<K> | void;
 export interface ActionObject<K> {

--- a/index.d.ts
+++ b/index.d.ts
@@ -5,11 +5,15 @@
 
 export type Listener<K> = (state: K, action?: Action<K>) => void;
 export type Unsubscribe = () => void;
-export type Action<K> = (state: K, ...args: any[]) => void;
-export type BoundAction = (...args: any[]) => void;
+export type ActionFn<K> = (state: K, store: Store<K>) => Promise<Partial<K>> | Partial<K> | void;
+export interface ActionObject<K> {
+  type: string;
+  action: ActionFn<K>;
+}
+export type Action<K> = ActionObject<K> | ActionFn<K>
 
 export interface Store<K> {
-	action(action: Action<K>): BoundAction;
+	action(action: Action<K>): Promise<void> | void;
 	setState<U extends keyof K>(update: Pick<K, U>, overwrite?: boolean, action?: Action<K>): void;
 	subscribe(f: Listener<K>): Unsubscribe;
 	unsubscribe(f: Listener<K>): void;
@@ -18,12 +22,10 @@ export interface Store<K> {
 
 export default function createStore<K>(state?: K): Store<K>;
 
-export type ActionFn<K> = (state: K, ...args: any[]) => Promise<Partial<K>> | Partial<K> | void;
-
 export interface ActionMap<K> {
-	[actionName: string]: ActionFn<K>;
+	[actionName: string]: ActionCreator<K>;
 }
 
-export type ActionCreator<K> = (store: Store<K>) => ActionMap<K>;
+export type ActionCreator<K> = (...args: any[]) => Action<K>;
 
 export type StateMapper<T, K, I> = (state: K, props: T) => I;

--- a/index.d.ts
+++ b/index.d.ts
@@ -5,12 +5,26 @@
 
 export type Listener<K> = (state: K, action?: Action<K>, update?: Partial<K>) => void;
 export type Unsubscribe = () => void;
-export type ActionFn<K> = (state: K, store: Store<K>) => Promise<Partial<K>> | Partial<K> | void;
-export interface ActionObject<K> {
+
+export type AsyncActionFn<K> = (getState: () => K, action: (action: Action<K>) => Promise<void> | void) => Promise<Partial<K> | void>;
+export type SyncActionFn<K> = (getState: () => K, action: (action: Action<K>) => Promise<void> | void) => Partial<K> | void;
+export type ActionFn<K> = AsyncActionFn<K> | SyncActionFn<K>;
+
+export type AsyncActionObject<K> = {
   type: string;
-  action: ActionFn<K>;
+  action: AsyncActionFn<K>;
 }
-export type Action<K> = ActionObject<K> | ActionFn<K>
+export type SyncActionObject<K> = {
+  type: string;
+  action: SyncActionFn<K>;
+}
+export type ActionObject<K> = AsyncActionObject<K> | SyncActionObject<K>;
+
+export type Action<K> = ActionObject<K> | ActionFn<K>;
+
+export type AsyncActionCreator<K> = (...args: any[]) => AsyncActionFn<K> | AsyncActionObject<K>;
+export type SyncActionCreator<K> = (...args: any[]) => SyncActionFn<K> | SyncActionObject<K>;
+export type ActionCreator<K> = AsyncActionCreator<K> | SyncActionCreator<K>;
 
 export interface Store<K> {
 	action(action: Action<K>): Promise<void> | void;
@@ -25,7 +39,5 @@ export default function createStore<K>(state?: K): Store<K>;
 export interface ActionMap<K> {
 	[actionName: string]: ActionCreator<K>;
 }
-
-export type ActionCreator<K> = (...args: any[]) => Action<K>;
 
 export type StateMapper<T, K, I> = (state: K, props: T) => I;

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
   "eslintConfig": {
     "extends": "eslint-config-developit",
     "rules": {
-      "prefer-rest-params": 0
+      "prefer-rest-params": 0,
+      "prefer-spread": 0
     }
   },
   "bundlesize": [

--- a/preact.d.ts
+++ b/preact.d.ts
@@ -8,7 +8,7 @@ declare module 'unistore/preact' {
 	import { StateMapper, Store, ActionCreatorsObject, MappedActionCreators  } from 'unistore';
 
 	export function connect<T, S, K, I, A extends ActionCreatorsObject<K>>(
-		mapStateToProps: string | Array<string> | StateMapper<T, K, I>,
+		mapStateToProps: string | Array<string> | StateMapper<T, K, I> | null,
 		actions?: A,
 	): (
 		Child: Preact.ComponentConstructor<T & I & MappedActionCreators<A>, S> | Preact.AnyComponent<T & I & MappedActionCreators<A>, S>

--- a/preact.d.ts
+++ b/preact.d.ts
@@ -5,13 +5,13 @@
 
 declare module 'unistore/preact' {
 	import * as Preact from 'preact';
-	import { ActionCreator, StateMapper, Store } from 'unistore';
+	import { StateMapper, Store, ActionCreatorsObject, MappedActionCreators  } from 'unistore';
 
-	export function connect<T, S, K, I>(
+	export function connect<T, S, K, I, A extends ActionCreatorsObject<K>>(
 		mapStateToProps: string | Array<string> | StateMapper<T, K, I>,
-		actions?: ActionCreator<K> | object
+		actions?: A,
 	): (
-		Child: Preact.ComponentConstructor<T & I, S> | Preact.AnyComponent<T & I, S>
+		Child: Preact.ComponentConstructor<T & I & MappedActionCreators<A>, S> | Preact.AnyComponent<T & I & MappedActionCreators<A>, S>
 	) => Preact.ComponentConstructor<T | T & I, S>;
 
 	export interface ProviderProps<T> {

--- a/preact.d.ts
+++ b/preact.d.ts
@@ -14,11 +14,11 @@ declare module 'unistore/preact' {
 		Child: Preact.ComponentConstructor<T & I & MappedActionCreators<A>, S> | Preact.AnyComponent<T & I & MappedActionCreators<A>, S>
 	) => Preact.ComponentConstructor<T | T & I, S>;
 
-	export interface ProviderProps<T> {
-		store: Store<T>;
+	export interface ProviderProps<K> {
+		store: Store<K>;
 	}
 
-	export class Provider<T> extends Preact.Component<ProviderProps<T>> {
-		render(props: ProviderProps<T>): Preact.JSX.Element;
+	export class Provider<K> extends Preact.Component<ProviderProps<K>> {
+		render(props: ProviderProps<K>): Preact.JSX.Element;
 	}
 }

--- a/react.d.ts
+++ b/react.d.ts
@@ -15,11 +15,11 @@ declare module 'unistore/react' {
 		Child: ((props: T & I & MappedActionCreators<A>) => React.ReactNode) | React.ComponentClass<T & I & MappedActionCreators<A>, S> | React.FC<T & I & MappedActionCreators<A>>
 	) => React.ComponentClass<T | T & I, S> | React.FC<T | T & I>;
 
-	export interface ProviderProps<T> {
-		store: Store<T>;
+	export interface ProviderProps<K> {
+		store: Store<K>;
 	}
 
-	export class Provider<T> extends React.Component<ProviderProps<T>, {}> {
+	export class Provider<K> extends React.Component<ProviderProps<K>, {}> {
 		render(): React.ReactNode;
 	}
 

--- a/react.d.ts
+++ b/react.d.ts
@@ -2,16 +2,17 @@
 // S - Wrapped component state
 // K - Store state
 // I - Injected props to wrapped component
+// A - actions
 
 declare module 'unistore/react' {
 	import * as React from 'react';
-	import { ActionCreator, StateMapper, Store } from 'unistore';
+	import { StateMapper, Store, ActionCreatorsObject, MappedActionCreators  } from 'unistore';
 
-	export function connect<T, S, K, I>(
+	export function connect<T, S, K, I, A extends ActionCreatorsObject<K>>(
 		mapStateToProps: string | Array<string> | StateMapper<T, K, I>,
-		actions?: ActionCreator<K> | object
+		actions?: A,
 	): (
-		Child: ((props: T & I) => React.ReactNode) | React.ComponentClass<T & I, S> | React.FC<T & I>
+		Child: ((props: T & I & MappedActionCreators<A>) => React.ReactNode) | React.ComponentClass<T & I & MappedActionCreators<A>, S> | React.FC<T & I & MappedActionCreators<A>>
 	) => React.ComponentClass<T | T & I, S> | React.FC<T | T & I>;
 
 	export interface ProviderProps<T> {

--- a/react.d.ts
+++ b/react.d.ts
@@ -9,7 +9,7 @@ declare module 'unistore/react' {
 	import { StateMapper, Store, ActionCreatorsObject, MappedActionCreators  } from 'unistore';
 
 	export function connect<T, S, K, I, A extends ActionCreatorsObject<K>>(
-		mapStateToProps: string | Array<string> | StateMapper<T, K, I>,
+		mapStateToProps: string | Array<string> | StateMapper<T, K, I> | null,
 		actions?: A,
 	): (
 		Child: ((props: T & I & MappedActionCreators<A>) => React.ReactNode) | React.ComponentClass<T & I & MappedActionCreators<A>, S> | React.FC<T & I & MappedActionCreators<A>>

--- a/src/index.js
+++ b/src/index.js
@@ -48,11 +48,11 @@ export default function createStore(state) {
 		 * @param {Function} action	An action of the form `action(state, ...args) -> stateUpdate`
 		 * @returns {Function} boundAction()
 		 */
-		action(action) {
+		dispatch(action) {
 			function apply(result) {
 				setState(result, false, action);
 			}
-			let ret = (action.action || action)(this.getState, this.action);
+			let ret = (action.action || action)(this.getState, this.dispatch);
 			if (ret != null) {
 				if (ret.then) return ret.then(apply);
 				return apply(ret);

--- a/src/index.js
+++ b/src/index.js
@@ -31,7 +31,7 @@ export default function createStore(state) {
 	function setState(update, overwrite, action) {
 		state = overwrite ? update : assign(assign({}, state), update);
 		let currentListeners = listeners;
-		for (let i=0; i<currentListeners.length; i++) currentListeners[i](state, action);
+		for (let i=0; i<currentListeners.length; i++) currentListeners[i](state, action, update);
 	}
 
 	/**

--- a/src/index.js
+++ b/src/index.js
@@ -52,17 +52,11 @@ export default function createStore(state) {
 			function apply(result) {
 				setState(result, false, action);
 			}
-
-			// Note: perf tests verifying this implementation: https://esbench.com/bench/5a295e6299634800a0349500
-			return function() {
-				let args = [state];
-				for (let i=0; i<arguments.length; i++) args.push(arguments[i]);
-				let ret = action.apply(this, args);
-				if (ret!=null) {
-					if (ret.then) return ret.then(apply);
-					return apply(ret);
-				}
-			};
+			let ret = (action.action || action)(state, this);
+			if (ret != null) {
+				if (ret.then) return ret.then(apply);
+				return apply(ret);
+			}
 		},
 
 		/**

--- a/src/index.js
+++ b/src/index.js
@@ -52,7 +52,7 @@ export default function createStore(state) {
 			function apply(result) {
 				setState(result, false, action);
 			}
-			let ret = (action.action || action)(state, this);
+			let ret = (action.action || action)(this.getState, this.action);
 			if (ret != null) {
 				if (ret.then) return ret.then(apply);
 				return apply(ret);

--- a/src/index.js
+++ b/src/index.js
@@ -28,6 +28,21 @@ export default function createStore(state) {
 		listeners = out;
 	}
 
+	function dispatch(action) {
+		function apply(result) {
+			setState(result, false, action);
+		}
+		let ret = (action.action || action)(getState, dispatch);
+		if (ret != null) {
+			if (ret.then) return ret.then(apply);
+			return apply(ret);
+		}
+	}
+
+	function getState() {
+		return state;
+	}
+
 	function setState(update, overwrite, action) {
 		state = overwrite ? update : assign(assign({}, state), update);
 		let currentListeners = listeners;
@@ -48,16 +63,7 @@ export default function createStore(state) {
 		 * @param {Function} action	An action of the form `action(state, ...args) -> stateUpdate`
 		 * @returns {Function} boundAction()
 		 */
-		dispatch(action) {
-			function apply(result) {
-				setState(result, false, action);
-			}
-			let ret = (action.action || action)(this.getState, this.dispatch);
-			if (ret != null) {
-				if (ret.then) return ret.then(apply);
-				return apply(ret);
-			}
-		},
+		dispatch,
 
 		/**
 		 * Apply a partial state object to the current state, invoking registered listeners.
@@ -87,8 +93,6 @@ export default function createStore(state) {
 		 * Retrieve the current state object.
 		 * @returns {Object} state
 		 */
-		getState() {
-			return state;
-		}
+		getState
 	};
 }

--- a/src/util.js
+++ b/src/util.js
@@ -1,9 +1,10 @@
 // Bind an object/factory of actions to the store and wrap them.
 export function mapActions(actions, store) {
-	if (typeof actions==='function') actions = actions(store);
 	let mapped = {};
 	for (let i in actions) {
-		mapped[i] = store.action(actions[i]);
+		mapped[i] = function () {
+			return store.action(actions[i].apply(actions, arguments));
+		};
 	}
 	return mapped;
 }

--- a/src/util.js
+++ b/src/util.js
@@ -3,7 +3,7 @@ export function mapActions(actions, store) {
 	let mapped = {};
 	for (let i in actions) {
 		mapped[i] = function () {
-			return store.action(actions[i].apply(actions, arguments));
+			return store.dispatch(actions[i].apply(actions, arguments));
 		};
 	}
 	return mapped;

--- a/test/preact/builds.test.js
+++ b/test/preact/builds.test.js
@@ -27,8 +27,8 @@ describe('build: default', () => {
 	describe('smoke test (preact)', () => {
 		it('should render', done => {
 			const { Provider, connect } = preact;
-			const actions = ({ getState, setState }) => ({
-				incrementTwice(state) {
+			const actions = {
+				incrementTwice: () => (state, { getState, setState }) => {
 					setState({ count: state.count + 1 });
 					return new Promise(r =>
 						setTimeout(() => {
@@ -36,7 +36,7 @@ describe('build: default', () => {
 						}, 20)
 					);
 				}
-			});
+			};
 			const App = connect('count', actions)(({ count, incrementTwice }) => (
 				<button onClick={incrementTwice}>count: {count}</button>
 			));

--- a/test/preact/builds.test.js
+++ b/test/preact/builds.test.js
@@ -28,8 +28,8 @@ describe('build: default', () => {
 		it('should render', done => {
 			const { Provider, connect } = preact;
 			const actions = {
-				incrementTwice: () => (state, { getState, setState }) => {
-					setState({ count: state.count + 1 });
+				incrementTwice: () => (getState, dispatch) => {
+					dispatch(() => ({ count: getState().count + 1 }));
 					return new Promise(r =>
 						setTimeout(() => {
 							r({ count: getState().count + 1 });

--- a/test/react/builds.test.js
+++ b/test/react/builds.test.js
@@ -33,8 +33,8 @@ describe('build: default', () => {
 	describe('smoke test (react)', () => {
 		it('should render', done => {
 			const { Provider, connect } = react;
-			const actions = ({ getState, setState }) => ({
-				incrementTwice(state) {
+			const actions = {
+				incrementTwice: () => (state, { getState, setState }) => {
 					setState({ count: state.count + 1 });
 					return new Promise(r =>
 						setTimeout(() => {
@@ -42,7 +42,7 @@ describe('build: default', () => {
 						}, 20)
 					);
 				}
-			});
+			};
 			const App = connect('count', actions)(({ count, incrementTwice }) => (
 				<button id="some_button" onClick={incrementTwice}>
 					count: {count}

--- a/test/react/builds.test.js
+++ b/test/react/builds.test.js
@@ -34,8 +34,8 @@ describe('build: default', () => {
 		it('should render', done => {
 			const { Provider, connect } = react;
 			const actions = {
-				incrementTwice: () => (state, { getState, setState }) => {
-					setState({ count: state.count + 1 });
+				incrementTwice: () => (getState, dispatch) => {
+          dispatch(() => ({ count: getState().count + 1 }))
 					return new Promise(r =>
 						setTimeout(() => {
 							r({ count: getState().count + 1 });

--- a/test/unistore.test.js
+++ b/test/unistore.test.js
@@ -36,15 +36,17 @@ describe('createStore()', () => {
 		let rval = store.subscribe(sub1);
 		expect(rval).toBeInstanceOf(Function);
 
-		store.setState({ a: 'b' });
-		expect(sub1).toBeCalledWith(store.getState(), action);
+		let update1 = { a: 'b' };
+		store.setState(update1);
+		expect(sub1).toBeCalledWith(store.getState(), action, update1);
 
 		store.subscribe(sub2);
-		store.setState({ c: 'd' });
+		let update2 = { c: 'd' };
+		store.setState(update2);
 
 		expect(sub1).toHaveBeenCalledTimes(2);
-		expect(sub1).toHaveBeenLastCalledWith(store.getState(), action);
-		expect(sub2).toBeCalledWith(store.getState(), action);
+		expect(sub1).toHaveBeenLastCalledWith(store.getState(), action, update2);
+		expect(sub2).toBeCalledWith(store.getState(), action, update2);
 	});
 
 	it('should unsubscribe', () => {


### PR DESCRIPTION
This PR rethinks actions and action creators. An action now simply becomes an
unbound function with two arguments, `state` and `store` (or only `store`, see
discussion below). More commonly a user will use action creators, which are
functions that return an action (function).

```js
// without argument
export const increment = () => (state, store) => ({
  count: state.count + 1,
})

// with argument
export const increment = (amount) => (state, store) => ({
  count: state.count + amount,
})
```

I'm beginning to question whether the state argument is really needed. Calling
`getState()` isn't that much extra work, and to avoid stale states it is
often required. The above example would then be:

```js
export const increment = (amount) => ({ getState }) => ({
  count: getState().count + amount,
})
```

I've also updated devtools to differentiate between unnamed actions and direct
calls to `setState`. Furthermore, the `update` argument passed to `setState` is now passed on to the subscribers. This was done to show the update object in devtools.

## Caveats

The only problem with this change is we no longer get naming of actions in
devtools for free. Now you have to name both the action creator and the action
function if you want to get a descriptive name for the action in devtools.
I've also implemented the ability to return an action object instead
of an action function, merely for naming purposes.

```js
export const increment = (amount) => function increment (state) {
  return { count: state.count + amount },
}

// OR

export const increment = (amount) => (state) => ({
  type: `increment by ${amount}`,
  action: (state) => ({ count: state.count + amount }),
});
```

## Why?

### 1. Easier to compose action maps for connected components

Before:

```js
import someActions from './someActions'
import moreActions from './moreActions'

connect('stuffs', store => ({
  ...someActions(store),
  ...moreActions(store),
}))(Component)

// or even worse, if we dont want to expose all actions:

connect('stuffs', store => {
  const { oneAction, twoAction } = someActions(store)
  const { anotherAction } = moreActions(store)

  return {
    oneAction,
    twoAction,
    anotherAction,
  }
})(Component)
```

Now:

```js
import * as someActions from './someActions'
import * as moreActions from './moreActions'

connect('stuffs', {
  ...someActions,
  ...moreActions,
})(Component)

// or even better:

import { oneAction, twoAction } from './someActions'
import { anotherAction } from './moreActions'

connect('stuffs', {
  oneAction,
  twoAction,
  anotherAction,
})(Component)
```

### 2. Easier to call actions from other actions:

Before:

```js
import otherActions from './otherActions'

export default (store) => ({
  anAction() {
    store.action(otherActions(store).anotherAction)()
    
    return {
      stuffs: ['interesting stuff'],
    }
  }
})
```

Now:

```js
import { anotherAction } from './otherActions'

export const anAction = () => (state, { action }) => {
  action(anotherAction())

  return {
    stuffs: ['interesting stuff'],
  }
}
```

### 3. A little easier to test

Since actions no longer need to be bound it becomes a little easier to test.

## Performance

I was initially worried creating new action functions every time an action is called would have negative performance impacts, but I was glad to see that the performance actually greatly improved. At least in modern browsers. The results in the table below are from <https://jsperf.com/binding-vs-action-creators>.

|            | Bind | Bound | Create | Mapped Create |
| ---------| ------ | --------- | --------- | ------------------- |
| Firefox<br>70.0.1 | 14,317,110 ±0.69%<br>75% slower | 17,701,729 ±1.76%<br>70% slower | __58,379,915 ±0.80%<br>fastest__ | 45,373,182 ±0.48%<br>22% slower |
| Chrome<br>78.0.3904.108 | 21,238,688 ±0.79%<br>56% slower | 30,728,667 ±0.80%<br>36% slower | __47,844,616 ±0.90%<br>fastest__ | 47,107,563 ±1.00%<br>2% slower  |
| Edge<br>44.18362.449.0 | 4,862,331 ±4.09 %<br>43% slower | __8,476,679 ±4.08%<br>fastest__ | 5,315,648 ±3.16%<br>37% slower | 1,689,862 ±2.47%<br>80% slower |
| IE 11 | 4,251,654 ±1.75%<br>29% slower | __5,965,267 ±1.68%<br>fastest__ | 4,322,828 ±1.49%<br>27% slower | 1,798,760 ±1.52%<br>70% slower |

## Build Size

The full preact and dist builds have shrunk quite a bit, while somehow the isolated preact build increased. File compression is a dark magic.

|             | full/preact.js |dist/unistore.js | preact.js |
| --------- | ------- | ------- | ----- |
| master | 760B | 355B | 546B |
| feature/new-action-creators| 737B | 327B | 558B |

## Notes

I had to disable the `prefer-spread` eslint rule to allow the modifications of
`mapAction` where `.apply(actions, arguments)` is used.