### PR TITLE
WIP Pass extra argument to actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ Returns **[store](#store)**
 
 An observable state container, returned from [createStore](#createstore)
 
-##### action
+##### dispatch
 
 Create a bound copy of the given action function.
 The bound returned function invokes action() and persists the result back to the store.

--- a/README.md
+++ b/README.md
@@ -191,6 +191,7 @@ Creates a new store, which is a tiny evented state container.
 **Parameters**
 
 - `state` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** Optional initial state (optional, default `{}`)
+- `extraArg`  
 
 **Examples**
 

--- a/devtools.d.ts
+++ b/devtools.d.ts
@@ -1,3 +1,3 @@
 import { Store } from "unistore";
 
-export default function unistoreDevTools<K>(store: Store<K>): Store<K>;
+export default function unistoreDevTools<K, E>(store: Store<K, E>): Store<K, E>;

--- a/devtools.js
+++ b/devtools.js
@@ -19,6 +19,7 @@ module.exports = function unistoreDevTools(store) {
 		});
 		store.devtools.init(store.getState());
 		store.subscribe(function (state, action, update) {
+			update = update || {};
 			var actionName = action
 				? action.type ||
 				  action.name ||

--- a/devtools.js
+++ b/devtools.js
@@ -18,11 +18,11 @@ module.exports = function unistoreDevTools(store) {
 			}
 		});
 		store.devtools.init(store.getState());
-		store.subscribe(function (state, action) {
+		store.subscribe(function (state, action, update) {
 			var actionName = action && (action.name || action.type) || 'setState';
 
 			if (!ignoreState) {
-				store.devtools.send(actionName, state);
+				store.devtools.send({ type: actionName, update: update }, state);
 			} else {
 				ignoreState = false;
 			}

--- a/devtools.js
+++ b/devtools.js
@@ -19,7 +19,7 @@ module.exports = function unistoreDevTools(store) {
 		});
 		store.devtools.init(store.getState());
 		store.subscribe(function (state, action) {
-			var actionName = action && action.name || 'setState';
+			var actionName = action && (action.name || action.type) || 'setState';
 
 			if (!ignoreState) {
 				store.devtools.send(actionName, state);

--- a/devtools.js
+++ b/devtools.js
@@ -19,7 +19,11 @@ module.exports = function unistoreDevTools(store) {
 		});
 		store.devtools.init(store.getState());
 		store.subscribe(function (state, action, update) {
-			var actionName = action ? action.type || action.name || 'Unnamed' : 'setState';
+			var actionName = action
+				? action.type ||
+				  action.name ||
+				  'N/A (' + (Object.keys(update).join(', ') || 'none') + ')'
+				: 'setState (' + (Object.keys(update).join(', ') || 'none') + ')';
 
 			if (!ignoreState) {
 				store.devtools.send({ type: actionName, update: update }, state);

--- a/devtools.js
+++ b/devtools.js
@@ -19,7 +19,7 @@ module.exports = function unistoreDevTools(store) {
 		});
 		store.devtools.init(store.getState());
 		store.subscribe(function (state, action, update) {
-			var actionName = action ? action.name || action.type || 'Unnamed' : 'setState';
+			var actionName = action ? action.type || action.name || 'Unnamed' : 'setState';
 
 			if (!ignoreState) {
 				store.devtools.send({ type: actionName, update: update }, state);

--- a/devtools.js
+++ b/devtools.js
@@ -19,7 +19,7 @@ module.exports = function unistoreDevTools(store) {
 		});
 		store.devtools.init(store.getState());
 		store.subscribe(function (state, action, update) {
-			var actionName = action && (action.name || action.type) || 'setState';
+			var actionName = action ? action.name || action.type || 'Unnamed' : 'setState';
 
 			if (!ignoreState) {
 				store.devtools.send({ type: actionName, update: update }, state);

--- a/index.d.ts
+++ b/index.d.ts
@@ -36,7 +36,7 @@ export type MappedActionCreators<A> = {
 
 
 export interface Store<K> {
-	action(action: Action<K>): Promise<void> | void;
+	dispatch(action: Action<K>): Promise<void> | void;
 	setState<U extends keyof K>(update: Pick<K, U>, overwrite?: boolean, action?: Action<K>): void;
 	subscribe(f: Listener<K>): Unsubscribe;
 	unsubscribe(f: Listener<K>): void;

--- a/index.d.ts
+++ b/index.d.ts
@@ -26,6 +26,15 @@ export type AsyncActionCreator<K> = (...args: any[]) => AsyncActionFn<K> | Async
 export type SyncActionCreator<K> = (...args: any[]) => SyncActionFn<K> | SyncActionObject<K>;
 export type ActionCreator<K> = AsyncActionCreator<K> | SyncActionCreator<K>;
 
+export type ActionCreatorsObject<K> = {
+  [actionCreator: string]: ActionCreator<K>
+}
+
+export type MappedActionCreators<A> = {
+  [P in keyof A]: A[P] extends AsyncActionCreator<any> ? (...args: any[]) => Promise<void> : (...args: any[]) => void
+}
+
+
 export interface Store<K> {
 	action(action: Action<K>): Promise<void> | void;
 	setState<U extends keyof K>(update: Pick<K, U>, overwrite?: boolean, action?: Action<K>): void;
@@ -35,9 +44,5 @@ export interface Store<K> {
 }
 
 export default function createStore<K>(state?: K): Store<K>;
-
-export interface ActionMap<K> {
-	[actionName: string]: ActionCreator<K>;
-}
 
 export type StateMapper<T, K, I> = (state: K, props: T) => I;

--- a/index.d.ts
+++ b/index.d.ts
@@ -3,7 +3,7 @@
 // K - Store state
 // I - Injected props to wrapped component
 
-export type Listener<K> = (state: K, action?: Action<K>) => void;
+export type Listener<K> = (state: K, action?: Action<K>, update?: Partial<K>) => void;
 export type Unsubscribe = () => void;
 export type ActionFn<K> = (state: K, store: Store<K>) => Promise<Partial<K>> | Partial<K> | void;
 export interface ActionObject<K> {

--- a/index.d.ts
+++ b/index.d.ts
@@ -3,46 +3,46 @@
 // K - Store state
 // I - Injected props to wrapped component
 
-export type Listener<K> = (state: K, action?: Action<K>, update?: Partial<K>) => void;
+export type Listener<K, E> = (state: K, action?: Action<K, E>, update?: Partial<K>) => void;
 export type Unsubscribe = () => void;
 
-export type AsyncActionFn<K> = (getState: () => K, action: (action: Action<K>) => Promise<void> | void) => Promise<Partial<K> | void>;
-export type SyncActionFn<K> = (getState: () => K, action: (action: Action<K>) => Promise<void> | void) => Partial<K> | void;
-export type ActionFn<K> = AsyncActionFn<K> | SyncActionFn<K>;
+export type AsyncActionFn<K, E> = (getState: () => K, action: (action: Action<K, E>) => Promise<void> | void, extraArg: E) => Promise<Partial<K> | void>;
+export type SyncActionFn<K, E> = (getState: () => K, action: (action: Action<K, E>, E) => Promise<void> | void, extraArg: E) => Partial<K> | void;
+export type ActionFn<K, E> = AsyncActionFn<K, E> | SyncActionFn<K, E>;
 
-export type AsyncActionObject<K> = {
+export type AsyncActionObject<K, E> = {
   type: string;
-  action: AsyncActionFn<K>;
+  action: AsyncActionFn<K, E>;
 }
-export type SyncActionObject<K> = {
+export type SyncActionObject<K, E> = {
   type: string;
-  action: SyncActionFn<K>;
+  action: SyncActionFn<K, E>;
 }
-export type ActionObject<K> = AsyncActionObject<K> | SyncActionObject<K>;
+export type ActionObject<K, E> = AsyncActionObject<K, E> | SyncActionObject<K, E>;
 
-export type Action<K> = ActionObject<K> | ActionFn<K>;
+export type Action<K, E> = ActionObject<K, E> | ActionFn<K, E>;
 
-export type AsyncActionCreator<K> = (...args: any[]) => AsyncActionFn<K> | AsyncActionObject<K>;
-export type SyncActionCreator<K> = (...args: any[]) => SyncActionFn<K> | SyncActionObject<K>;
-export type ActionCreator<K> = AsyncActionCreator<K> | SyncActionCreator<K>;
+export type AsyncActionCreator<K, E> = (...args: any[]) => AsyncActionFn<K, E> | AsyncActionObject<K, E>;
+export type SyncActionCreator<K, E> = (...args: any[]) => SyncActionFn<K, E> | SyncActionObject<K, E>;
+export type ActionCreator<K, E> = AsyncActionCreator<K, E> | SyncActionCreator<K, E>;
 
-export type ActionCreatorsObject<K> = {
-  [actionCreator: string]: ActionCreator<K>
+export type ActionCreatorsObject<K, E> = {
+  [actionCreator: string]: ActionCreator<K, E>
 }
 
 export type MappedActionCreators<A> = {
-  [P in keyof A]: A[P] extends AsyncActionCreator<any> ? (...args: any[]) => Promise<void> : (...args: any[]) => void
+  [P in keyof A]: A[P] extends AsyncActionCreator<any, any> ? (...args: any[]) => Promise<void> : (...args: any[]) => void
 }
 
 
-export interface Store<K> {
-	dispatch(action: Action<K>): Promise<void> | void;
-	setState<U extends keyof K>(update: Pick<K, U>, overwrite?: boolean, action?: Action<K>): void;
-	subscribe(f: Listener<K>): Unsubscribe;
-	unsubscribe(f: Listener<K>): void;
+export interface Store<K, E> {
+	dispatch(action: Action<K, E>): Promise<void> | void;
+	setState<U extends keyof K>(update: Pick<K, U>, overwrite?: boolean, action?: Action<K, E>): void;
+	subscribe(f: Listener<K, E>): Unsubscribe;
+	unsubscribe(f: Listener<K, E>): void;
 	getState(): K;
 }
 
-export default function createStore<K>(state?: K): Store<K>;
+export default function createStore<K, E>(state?: K, extraArg?: E): Store<K, E>;
 
 export type StateMapper<T, K, I> = (state: K, props: T) => I;

--- a/index.d.ts
+++ b/index.d.ts
@@ -5,11 +5,15 @@
 
 export type Listener<K> = (state: K, action?: Action<K>) => void;
 export type Unsubscribe = () => void;
-export type Action<K> = (state: K, ...args: any[]) => void;
-export type BoundAction = (...args: any[]) => void;
+export type ActionFn<K> = (state: K, store: Store<K>) => Promise<Partial<K>> | Partial<K> | void;
+export interface ActionObject<K> {
+  type: string;
+  action: ActionFn<K>;
+}
+export type Action<K> = ActionObject<K> | ActionFn<K>
 
 export interface Store<K> {
-	action(action: Action<K>): BoundAction;
+	action(action: Action<K>): Promise<void> | void;
 	setState<U extends keyof K>(update: Pick<K, U>, overwrite?: boolean, action?: Action<K>): void;
 	subscribe(f: Listener<K>): Unsubscribe;
 	unsubscribe(f: Listener<K>): void;
@@ -18,12 +22,10 @@ export interface Store<K> {
 
 export default function createStore<K>(state?: K): Store<K>;
 
-export type ActionFn<K> = (state: K, ...args: any[]) => Promise<Partial<K>> | Partial<K> | void;
-
 export interface ActionMap<K> {
-	[actionName: string]: ActionFn<K>;
+	[actionName: string]: ActionCreator<K>;
 }
 
-export type ActionCreator<K> = (store: Store<K>) => ActionMap<K>;
+export type ActionCreator<K> = (...args: any[]) => Action<K>;
 
 export type StateMapper<T, K, I> = (state: K, props: T) => I;

--- a/index.d.ts
+++ b/index.d.ts
@@ -5,12 +5,26 @@
 
 export type Listener<K> = (state: K, action?: Action<K>, update?: Partial<K>) => void;
 export type Unsubscribe = () => void;
-export type ActionFn<K> = (state: K, store: Store<K>) => Promise<Partial<K>> | Partial<K> | void;
-export interface ActionObject<K> {
+
+export type AsyncActionFn<K> = (getState: () => K, action: (action: Action<K>) => Promise<void> | void) => Promise<Partial<K> | void>;
+export type SyncActionFn<K> = (getState: () => K, action: (action: Action<K>) => Promise<void> | void) => Partial<K> | void;
+export type ActionFn<K> = AsyncActionFn<K> | SyncActionFn<K>;
+
+export type AsyncActionObject<K> = {
   type: string;
-  action: ActionFn<K>;
+  action: AsyncActionFn<K>;
 }
-export type Action<K> = ActionObject<K> | ActionFn<K>
+export type SyncActionObject<K> = {
+  type: string;
+  action: SyncActionFn<K>;
+}
+export type ActionObject<K> = AsyncActionObject<K> | SyncActionObject<K>;
+
+export type Action<K> = ActionObject<K> | ActionFn<K>;
+
+export type AsyncActionCreator<K> = (...args: any[]) => AsyncActionFn<K> | AsyncActionObject<K>;
+export type SyncActionCreator<K> = (...args: any[]) => SyncActionFn<K> | SyncActionObject<K>;
+export type ActionCreator<K> = AsyncActionCreator<K> | SyncActionCreator<K>;
 
 export interface Store<K> {
 	action(action: Action<K>): Promise<void> | void;
@@ -25,7 +39,5 @@ export default function createStore<K>(state?: K): Store<K>;
 export interface ActionMap<K> {
 	[actionName: string]: ActionCreator<K>;
 }
-
-export type ActionCreator<K> = (...args: any[]) => Action<K>;
 
 export type StateMapper<T, K, I> = (state: K, props: T) => I;

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
   "eslintConfig": {
     "extends": "eslint-config-developit",
     "rules": {
-      "prefer-rest-params": 0
+      "prefer-rest-params": 0,
+      "prefer-spread": 0
     }
   },
   "bundlesize": [

--- a/preact.d.ts
+++ b/preact.d.ts
@@ -8,7 +8,7 @@ declare module 'unistore/preact' {
 	import { StateMapper, Store, ActionCreatorsObject, MappedActionCreators  } from 'unistore';
 
 	export function connect<T, S, K, I, A extends ActionCreatorsObject<K>>(
-		mapStateToProps: string | Array<string> | StateMapper<T, K, I>,
+		mapStateToProps: string | Array<string> | StateMapper<T, K, I> | null,
 		actions?: A,
 	): (
 		Child: Preact.ComponentConstructor<T & I & MappedActionCreators<A>, S> | Preact.AnyComponent<T & I & MappedActionCreators<A>, S>

--- a/preact.d.ts
+++ b/preact.d.ts
@@ -7,15 +7,15 @@ declare module 'unistore/preact' {
 	import * as Preact from 'preact';
 	import { StateMapper, Store, ActionCreatorsObject, MappedActionCreators  } from 'unistore';
 
-	export function connect<T, S, K, I, A extends ActionCreatorsObject<K>>(
+	export function connect<T, S, K, I, A extends ActionCreatorsObject<K, E>, E = any>(
 		mapStateToProps: string | Array<string> | StateMapper<T, K, I> | null,
 		actions?: A,
 	): (
 		Child: Preact.ComponentConstructor<T & I & MappedActionCreators<A>, S> | Preact.AnyComponent<T & I & MappedActionCreators<A>, S>
 	) => Preact.ComponentConstructor<T | T & I, S>;
 
-	export interface ProviderProps<K> {
-		store: Store<K>;
+	export interface ProviderProps<K, E = any> {
+		store: Store<K, E>;
 	}
 
 	export class Provider<K> extends Preact.Component<ProviderProps<K>> {

--- a/preact.d.ts
+++ b/preact.d.ts
@@ -5,13 +5,13 @@
 
 declare module 'unistore/preact' {
 	import * as Preact from 'preact';
-	import { ActionCreator, StateMapper, Store } from 'unistore';
+	import { StateMapper, Store, ActionCreatorsObject, MappedActionCreators  } from 'unistore';
 
-	export function connect<T, S, K, I>(
+	export function connect<T, S, K, I, A extends ActionCreatorsObject<K>>(
 		mapStateToProps: string | Array<string> | StateMapper<T, K, I>,
-		actions?: ActionCreator<K> | object
+		actions?: A,
 	): (
-		Child: Preact.ComponentConstructor<T & I, S> | Preact.AnyComponent<T & I, S>
+		Child: Preact.ComponentConstructor<T & I & MappedActionCreators<A>, S> | Preact.AnyComponent<T & I & MappedActionCreators<A>, S>
 	) => Preact.ComponentConstructor<T | T & I, S>;
 
 	export interface ProviderProps<T> {

--- a/preact.d.ts
+++ b/preact.d.ts
@@ -14,11 +14,11 @@ declare module 'unistore/preact' {
 		Child: Preact.ComponentConstructor<T & I & MappedActionCreators<A>, S> | Preact.AnyComponent<T & I & MappedActionCreators<A>, S>
 	) => Preact.ComponentConstructor<T | T & I, S>;
 
-	export interface ProviderProps<T> {
-		store: Store<T>;
+	export interface ProviderProps<K> {
+		store: Store<K>;
 	}
 
-	export class Provider<T> extends Preact.Component<ProviderProps<T>> {
-		render(props: ProviderProps<T>): Preact.JSX.Element;
+	export class Provider<K> extends Preact.Component<ProviderProps<K>> {
+		render(props: ProviderProps<K>): Preact.JSX.Element;
 	}
 }

--- a/react.d.ts
+++ b/react.d.ts
@@ -15,11 +15,11 @@ declare module 'unistore/react' {
 		Child: ((props: T & I & MappedActionCreators<A>) => React.ReactNode) | React.ComponentClass<T & I & MappedActionCreators<A>, S> | React.FC<T & I & MappedActionCreators<A>>
 	) => React.ComponentClass<T | T & I, S> | React.FC<T | T & I>;
 
-	export interface ProviderProps<T> {
-		store: Store<T>;
+	export interface ProviderProps<K> {
+		store: Store<K>;
 	}
 
-	export class Provider<T> extends React.Component<ProviderProps<T>, {}> {
+	export class Provider<K> extends React.Component<ProviderProps<K>, {}> {
 		render(): React.ReactNode;
 	}
 

--- a/react.d.ts
+++ b/react.d.ts
@@ -2,16 +2,17 @@
 // S - Wrapped component state
 // K - Store state
 // I - Injected props to wrapped component
+// A - actions
 
 declare module 'unistore/react' {
 	import * as React from 'react';
-	import { ActionCreator, StateMapper, Store } from 'unistore';
+	import { StateMapper, Store, ActionCreatorsObject, MappedActionCreators  } from 'unistore';
 
-	export function connect<T, S, K, I>(
+	export function connect<T, S, K, I, A extends ActionCreatorsObject<K>>(
 		mapStateToProps: string | Array<string> | StateMapper<T, K, I>,
-		actions?: ActionCreator<K> | object
+		actions?: A,
 	): (
-		Child: ((props: T & I) => React.ReactNode) | React.ComponentClass<T & I, S> | React.FC<T & I>
+		Child: ((props: T & I & MappedActionCreators<A>) => React.ReactNode) | React.ComponentClass<T & I & MappedActionCreators<A>, S> | React.FC<T & I & MappedActionCreators<A>>
 	) => React.ComponentClass<T | T & I, S> | React.FC<T | T & I>;
 
 	export interface ProviderProps<T> {

--- a/react.d.ts
+++ b/react.d.ts
@@ -9,7 +9,7 @@ declare module 'unistore/react' {
 	import { StateMapper, Store, ActionCreatorsObject, MappedActionCreators  } from 'unistore';
 
 	export function connect<T, S, K, I, A extends ActionCreatorsObject<K>>(
-		mapStateToProps: string | Array<string> | StateMapper<T, K, I>,
+		mapStateToProps: string | Array<string> | StateMapper<T, K, I> | null,
 		actions?: A,
 	): (
 		Child: ((props: T & I & MappedActionCreators<A>) => React.ReactNode) | React.ComponentClass<T & I & MappedActionCreators<A>, S> | React.FC<T & I & MappedActionCreators<A>>

--- a/react.d.ts
+++ b/react.d.ts
@@ -8,15 +8,15 @@ declare module 'unistore/react' {
 	import * as React from 'react';
 	import { StateMapper, Store, ActionCreatorsObject, MappedActionCreators  } from 'unistore';
 
-	export function connect<T, S, K, I, A extends ActionCreatorsObject<K>>(
+	export function connect<T, S, K, I, A extends ActionCreatorsObject<K, E>, E = any>(
 		mapStateToProps: string | Array<string> | StateMapper<T, K, I> | null,
 		actions?: A,
 	): (
 		Child: ((props: T & I & MappedActionCreators<A>) => React.ReactNode) | React.ComponentClass<T & I & MappedActionCreators<A>, S> | React.FC<T & I & MappedActionCreators<A>>
 	) => React.ComponentClass<T | T & I, S> | React.FC<T | T & I>;
 
-	export interface ProviderProps<K> {
-		store: Store<K>;
+	export interface ProviderProps<K, E = any> {
+		store: Store<K, E>;
 	}
 
 	export class Provider<K> extends React.Component<ProviderProps<K>, {}> {

--- a/src/index.js
+++ b/src/index.js
@@ -11,7 +11,7 @@ import { assign } from './util';
  * store.setState({ a: 'b' });   // logs { a: 'b' }
  * store.setState({ c: 'd' });   // logs { a: 'b', c: 'd' }
  */
-export default function createStore(state) {
+export default function createStore(state, extraArg) {
 	let listeners = [];
 	state = state || {};
 
@@ -32,7 +32,7 @@ export default function createStore(state) {
 		function apply(result) {
 			setState(result, false, action);
 		}
-		let ret = (action.action || action)(getState, dispatch);
+		let ret = (action.action || action)(getState, dispatch, extraArg);
 		if (ret != null) {
 			if (ret.then) return ret.then(apply);
 			return apply(ret);

--- a/src/index.js
+++ b/src/index.js
@@ -48,11 +48,11 @@ export default function createStore(state) {
 		 * @param {Function} action	An action of the form `action(state, ...args) -> stateUpdate`
 		 * @returns {Function} boundAction()
 		 */
-		action(action) {
+		dispatch(action) {
 			function apply(result) {
 				setState(result, false, action);
 			}
-			let ret = (action.action || action)(this.getState, this.action);
+			let ret = (action.action || action)(this.getState, this.dispatch);
 			if (ret != null) {
 				if (ret.then) return ret.then(apply);
 				return apply(ret);

--- a/src/index.js
+++ b/src/index.js
@@ -31,7 +31,7 @@ export default function createStore(state) {
 	function setState(update, overwrite, action) {
 		state = overwrite ? update : assign(assign({}, state), update);
 		let currentListeners = listeners;
-		for (let i=0; i<currentListeners.length; i++) currentListeners[i](state, action);
+		for (let i=0; i<currentListeners.length; i++) currentListeners[i](state, action, update);
 	}
 
 	/**

--- a/src/index.js
+++ b/src/index.js
@@ -52,17 +52,11 @@ export default function createStore(state) {
 			function apply(result) {
 				setState(result, false, action);
 			}
-
-			// Note: perf tests verifying this implementation: https://esbench.com/bench/5a295e6299634800a0349500
-			return function() {
-				let args = [state];
-				for (let i=0; i<arguments.length; i++) args.push(arguments[i]);
-				let ret = action.apply(this, args);
-				if (ret!=null) {
-					if (ret.then) return ret.then(apply);
-					return apply(ret);
-				}
-			};
+			let ret = (action.action || action)(state, this);
+			if (ret != null) {
+				if (ret.then) return ret.then(apply);
+				return apply(ret);
+			}
 		},
 
 		/**

--- a/src/index.js
+++ b/src/index.js
@@ -52,7 +52,7 @@ export default function createStore(state) {
 			function apply(result) {
 				setState(result, false, action);
 			}
-			let ret = (action.action || action)(state, this);
+			let ret = (action.action || action)(this.getState, this.action);
 			if (ret != null) {
 				if (ret.then) return ret.then(apply);
 				return apply(ret);

--- a/src/index.js
+++ b/src/index.js
@@ -28,6 +28,21 @@ export default function createStore(state) {
 		listeners = out;
 	}
 
+	function dispatch(action) {
+		function apply(result) {
+			setState(result, false, action);
+		}
+		let ret = (action.action || action)(getState, dispatch);
+		if (ret != null) {
+			if (ret.then) return ret.then(apply);
+			return apply(ret);
+		}
+	}
+
+	function getState() {
+		return state;
+	}
+
 	function setState(update, overwrite, action) {
 		state = overwrite ? update : assign(assign({}, state), update);
 		let currentListeners = listeners;
@@ -48,16 +63,7 @@ export default function createStore(state) {
 		 * @param {Function} action	An action of the form `action(state, ...args) -> stateUpdate`
 		 * @returns {Function} boundAction()
 		 */
-		dispatch(action) {
-			function apply(result) {
-				setState(result, false, action);
-			}
-			let ret = (action.action || action)(this.getState, this.dispatch);
-			if (ret != null) {
-				if (ret.then) return ret.then(apply);
-				return apply(ret);
-			}
-		},
+		dispatch,
 
 		/**
 		 * Apply a partial state object to the current state, invoking registered listeners.
@@ -87,8 +93,6 @@ export default function createStore(state) {
 		 * Retrieve the current state object.
 		 * @returns {Object} state
 		 */
-		getState() {
-			return state;
-		}
+		getState
 	};
 }

--- a/src/util.js
+++ b/src/util.js
@@ -1,9 +1,10 @@
 // Bind an object/factory of actions to the store and wrap them.
 export function mapActions(actions, store) {
-	if (typeof actions==='function') actions = actions(store);
 	let mapped = {};
 	for (let i in actions) {
-		mapped[i] = store.action(actions[i]);
+		mapped[i] = function () {
+			return store.action(actions[i].apply(actions, arguments));
+		};
 	}
 	return mapped;
 }

--- a/src/util.js
+++ b/src/util.js
@@ -3,7 +3,7 @@ export function mapActions(actions, store) {
 	let mapped = {};
 	for (let i in actions) {
 		mapped[i] = function () {
-			return store.action(actions[i].apply(actions, arguments));
+			return store.dispatch(actions[i].apply(actions, arguments));
 		};
 	}
 	return mapped;

--- a/test/preact/builds.test.js
+++ b/test/preact/builds.test.js
@@ -27,8 +27,8 @@ describe('build: default', () => {
 	describe('smoke test (preact)', () => {
 		it('should render', done => {
 			const { Provider, connect } = preact;
-			const actions = ({ getState, setState }) => ({
-				incrementTwice(state) {
+			const actions = {
+				incrementTwice: () => (state, { getState, setState }) => {
 					setState({ count: state.count + 1 });
 					return new Promise(r =>
 						setTimeout(() => {
@@ -36,7 +36,7 @@ describe('build: default', () => {
 						}, 20)
 					);
 				}
-			});
+			};
 			const App = connect('count', actions)(({ count, incrementTwice }) => (
 				<button onClick={incrementTwice}>count: {count}</button>
 			));

--- a/test/preact/builds.test.js
+++ b/test/preact/builds.test.js
@@ -28,8 +28,8 @@ describe('build: default', () => {
 		it('should render', done => {
 			const { Provider, connect } = preact;
 			const actions = {
-				incrementTwice: () => (state, { getState, setState }) => {
-					setState({ count: state.count + 1 });
+				incrementTwice: () => (getState, dispatch) => {
+					dispatch(() => ({ count: getState().count + 1 }));
 					return new Promise(r =>
 						setTimeout(() => {
 							r({ count: getState().count + 1 });

--- a/test/react/builds.test.js
+++ b/test/react/builds.test.js
@@ -33,8 +33,8 @@ describe('build: default', () => {
 	describe('smoke test (react)', () => {
 		it('should render', done => {
 			const { Provider, connect } = react;
-			const actions = ({ getState, setState }) => ({
-				incrementTwice(state) {
+			const actions = {
+				incrementTwice: () => (state, { getState, setState }) => {
 					setState({ count: state.count + 1 });
 					return new Promise(r =>
 						setTimeout(() => {
@@ -42,7 +42,7 @@ describe('build: default', () => {
 						}, 20)
 					);
 				}
-			});
+			};
 			const App = connect('count', actions)(({ count, incrementTwice }) => (
 				<button id="some_button" onClick={incrementTwice}>
 					count: {count}

--- a/test/react/builds.test.js
+++ b/test/react/builds.test.js
@@ -34,8 +34,8 @@ describe('build: default', () => {
 		it('should render', done => {
 			const { Provider, connect } = react;
 			const actions = {
-				incrementTwice: () => (state, { getState, setState }) => {
-					setState({ count: state.count + 1 });
+				incrementTwice: () => (getState, dispatch) => {
+          dispatch(() => ({ count: getState().count + 1 }))
 					return new Promise(r =>
 						setTimeout(() => {
 							r({ count: getState().count + 1 });

--- a/test/unistore.test.js
+++ b/test/unistore.test.js
@@ -36,15 +36,17 @@ describe('createStore()', () => {
 		let rval = store.subscribe(sub1);
 		expect(rval).toBeInstanceOf(Function);
 
-		store.setState({ a: 'b' });
-		expect(sub1).toBeCalledWith(store.getState(), action);
+		let update1 = { a: 'b' };
+		store.setState(update1);
+		expect(sub1).toBeCalledWith(store.getState(), action, update1);
 
 		store.subscribe(sub2);
-		store.setState({ c: 'd' });
+		let update2 = { c: 'd' };
+		store.setState(update2);
 
 		expect(sub1).toHaveBeenCalledTimes(2);
-		expect(sub1).toHaveBeenLastCalledWith(store.getState(), action);
-		expect(sub2).toBeCalledWith(store.getState(), action);
+		expect(sub1).toHaveBeenLastCalledWith(store.getState(), action, update2);
+		expect(sub2).toBeCalledWith(store.getState(), action, update2);
 	});
 
 	it('should unsubscribe', () => {


### PR DESCRIPTION
This PR implements the option to initialize a store with an extra argument that will be passed to each invocation of action functions. This is very similar to the extra argument option in [redux-thunk#injecting-a-custom-argument](https://github.com/reduxjs/redux-thunk#injecting-a-custom-argument).

This branch is based on my [new actions branch/PR](https://github.com/developit/unistore/pull/182). The other branch should be merged before this as implementing this functionality on the current actions logic would get kind of confusing.

```js
const store = createStore({}, api)

const action = (query) => async (state, store, api) => ({
  stuff: await api(query),
})

// multiple arguments

const store = createStore({}, { api, whatever })

const action = (query) => async (state, store, { api, whatever }) => ({
  stuff: whatever(await api(query)),
})
```


## Why?

### Isomorphic actions / SSR

There are several use cases, an obvious one is passing different fetch implementations or similar
depending on if it is server or client side rendered.

```js
// frontend
import rek from 'rek'

const store = createStore({}, rek)

// server
import rek from 'rek'

const store = createStore({}, rek.extend({ baseUrl: 'http://localhost:1337' }))

// isomorphic action
export const fetchCars = () => (state, store, rek) => (
  rek('/api/cars').json().then(cars => ({ cars }))
)
```

### Easier testing

If the action uses browser globals, they have to be mocked:

```js
export const fetchCars = () => (state, store) => (
  fetch('/api/cars').then(res => res.json()).then(cars => ({ cars }))
)
```

To test the following either a mock server has to be running, or something like [proxyquire](https://github.com/thlorenz/proxyquire) be used:

```js
import fetch from 'node-fetch'

export const fetchCars = () => (state, store) => (
  fetch('/api/cars').then(res => res.json()).then(cars => ({ cars }))
)
```

Both problems above are solved by passing in a `fetch` argument. Then we simply pass in a mock `fetch` when testing:

```js
export const fetchCars = () => (state, store, fetch) => (...)
```

## Build Size

|             | full/preact.js |dist/unistore.js | preact.js |
| --------- | ------- | ------- | ----- |
| master | 760B | 355B | 546B |
| feature/new-action-creators| 737B | 327B | 558B |
| feature/extra-arguments | 738B | 328B | 558B |