### PR TITLE
Fix for issue #171

### DIFF
--- a/src/integrations/react.js
+++ b/src/integrations/react.js
@@ -39,7 +39,7 @@ export function connect(mapStateToProps, actions) {
 					return this.forceUpdate();
 				}
 			};
-			this.componentWillReceiveProps = p => {
+			this.UNSAFE_componentWillReceiveProps = p => {
 				props = p;
 				update();
 			};


### PR DESCRIPTION
This PR fixes bug #171 

componentWillReceiveProps will be removed from React from version 17+

This PR replaces componentWillReceiveProps with UNSAFE_componentWillReceiveProps to still function the same but will work with next major React version.